### PR TITLE
docs: add initial project documentation baseline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,344 @@
+# AGENTS.md
+
+This file defines the operating contract for agentic coding agents and human contributors working in this repository.
+
+The repository is currently in the pre-implementation phase. The codebase is still being bootstrapped, but the product direction, architecture decisions, workflow rules, and documentation expectations are already defined here.
+
+## 1. Source of truth
+
+- The GitHub repository issues in `creep1ng/shared-expenses-tracking` are the canonical source of product scope and feature intent.
+- Do not invent major features outside the issue tracker unless the user explicitly requests it.
+- If a change introduces a new architectural or process rule, update the appropriate docs in the same branch.
+
+## 2. Product orientation
+
+This application is a workspace-based expense tracking system for:
+
+- personal finance management
+- shared finances with a partner
+- transaction registration and analysis
+- net balance visibility for shared expenses
+
+Primary product principle:
+
+- a personal workspace is a one-member workspace
+- a shared workspace uses the same domain model with multiple members
+
+## 3. Mandatory workflow
+
+This repository follows GitHub Flow.
+
+Rules:
+
+- branch from `main`
+- keep branches focused and short-lived
+- prefer one issue per branch unless changes are tightly coupled
+- open a PR back into `main`
+- keep `main` releasable
+
+Recommended branch naming:
+
+- `feature/<issue-number>-<short-slug>`
+- `fix/<issue-number>-<short-slug>`
+- `docs/<short-slug>`
+- `adr/<short-slug>`
+- `spike/<short-slug>`
+
+## 4. Shared Definition of Done
+
+The following Definition of Done applies to all issues and must be treated as mandatory:
+
+- [ ] Functionality: All the elements of the issue's Acceptance Criteria must be completed.
+- [ ] Code: The code works, it runs locally and it's integrated on the goal branch without breaking the system.
+- [ ] Quality: The code passes the linter, type checks and automated validations.
+- [ ] Testing coverage: There are tests according to the change and all the required tests passes the CI validation.
+- [ ] Bugs: There aren't critical bugs associated with the implementation.
+- [ ] Docs: There were updated the technical documentation, README, API contracts, diagrams or use notes if the implementation requires it.
+
+## 5. Definition of Ready expectations
+
+Before implementation starts, an issue should be clear about:
+
+- user or business problem
+- acceptance criteria
+- dependencies
+- affected architecture, data, API, and UI areas
+- whether an ADR is needed
+- whether documentation or Mermaid diagrams are expected to change
+
+## 6. Expected repository structure
+
+The repository should evolve toward this shape:
+
+```text
+backend/
+frontend/
+docs/
+  adr/
+  architecture/
+  process/
+  product/
+Makefile
+docker-compose.yml
+.env.example
+README.md
+AGENTS.md
+```
+
+Do not create ad hoc top-level folders when an existing location is appropriate.
+
+## 7. Approved stack
+
+### Frontend
+
+- Next.js
+- TypeScript
+- Tailwind CSS
+- shadcn/ui
+- React Hook Form
+- Zod
+- TanStack Query
+- **Language: Spanish (es)**
+
+### Backend
+
+- Python 3.13
+- FastAPI
+- Pydantic v2
+- SQLAlchemy 2.x
+- Alembic
+- PostgreSQL
+- Redis
+
+### Tooling and quality
+
+- uv
+- Ruff
+- mypy
+- pytest
+- Vitest
+- Playwright
+
+### Infrastructure
+
+- Docker
+- Docker Compose
+- GitHub Actions
+
+## 8. Architecture rules
+
+- Treat the system as a monorepo with separate frontend and backend applications.
+- Use a same-parent-domain deployment model by default.
+- Prefer backend-issued secure cookie sessions over client-managed auth tokens in local storage.
+- Put business rules in backend domain/service layers, not route handlers and not UI components.
+- Model personal and shared use through the workspace abstraction.
+- Store money in integer minor units, never floating-point values.
+- Transfers must be represented as first-class transfer movements and excluded from income/expense analytics.
+- Keep split logic simple in MVP. Do not prematurely implement itemized multi-segment transaction splitting unless explicitly required.
+
+## 9. Documentation obligations
+
+Documentation is part of implementation, not an optional afterthought.
+
+Always assess whether a change affects:
+
+- `README.md`
+- `AGENTS.md`
+- product docs
+- API contracts
+- architecture docs
+- Mermaid diagrams
+- ADRs
+
+If a change affects architecture, data model, runtime flow, or contributor workflow, update docs in the same branch.
+
+## 10. ADR policy
+
+Create or update an ADR for decisions that are:
+
+- difficult to reverse
+- cross-cutting
+- impactful to multiple future features
+- important for future contributors to understand
+
+Typical ADR topics include:
+
+- stack choices
+- auth strategy
+- money representation
+- session model
+- deployment model
+- data model rules
+- authorization model
+- background job approach
+
+## 11. Mermaid rules
+
+Mermaid is the default diagram format for this repository.
+
+Use the appropriate diagram type:
+
+- C4-style diagrams for system and container architecture
+- ER diagrams for data model and schema relationships
+- sequence diagrams for request and workflow interactions
+- flowcharts for business decisions or process steps
+
+Keep diagrams close to the docs they explain. Do not use external binary diagram assets unless unavoidable.
+
+## 12. Code style expectations
+
+### General
+
+- Prefer clear, explicit code over clever code.
+- Optimize for maintainability and auditability.
+- Keep functions focused and side effects controlled.
+- Avoid hidden coupling between frontend and backend logic.
+
+### Python / FastAPI
+
+- Use explicit typing on public functions, service methods, and data structures.
+- Use Pydantic models for API contracts and validation.
+- Use SQLAlchemy 2.x typed ORM patterns.
+- Keep route handlers thin; move domain logic into services.
+- Prefer dependency injection through FastAPI dependencies for infrastructure concerns.
+- Raise domain-specific or HTTP-specific errors deliberately; do not swallow exceptions.
+- Validate external input at boundaries.
+- Use structured logging where relevant.
+
+### TypeScript / Next.js
+
+- Use TypeScript strictly; avoid `any` unless unavoidable and documented.
+- Keep React components small and composable.
+- Use Zod for form and API-boundary validation on the frontend where appropriate.
+- Use server state libraries for remote data, not ad hoc global state.
+- Avoid embedding business calculations in UI components.
+- Favor semantic and accessible UI primitives.
+
+## 13. Imports, formatting, naming, and types
+
+### Imports
+
+- Group imports by standard library, third-party, then local imports.
+- Avoid circular dependencies.
+- Prefer absolute or well-defined module imports over brittle deep relative chains.
+
+### Formatting
+
+- Python formatting should be handled by Ruff format.
+- Frontend formatting should be handled by Prettier.
+- Do not introduce style drift that conflicts with project tooling.
+
+### Naming
+
+- Use descriptive names that reflect domain intent.
+- Python modules and functions: `snake_case`
+- Python classes: `PascalCase`
+- TypeScript variables/functions: `camelCase`
+- React components and types: `PascalCase`
+- Constants: `UPPER_SNAKE_CASE` when genuinely constant
+
+### Types
+
+- Avoid untyped public interfaces.
+- Prefer narrow, explicit types to loose dictionaries and unstructured objects.
+- Treat validation schemas and API models as part of the domain contract.
+
+## 14. Error handling rules
+
+- Handle expected business errors explicitly.
+- Return clear, user-safe API errors for invalid actions and permission failures.
+- Do not leak internal implementation details in API error responses.
+- Validate authorization on protected workspace actions.
+- Use confirmation flows for destructive actions in the UI.
+
+## 15. Testing rules
+
+- Write tests proportional to the change.
+- Prioritize backend integration tests for financial workflows and authorization.
+- Use frontend component tests for critical form and interaction behavior.
+- Use Playwright for end-to-end happy-path user flows.
+- Do not rely only on manual testing for financial logic.
+
+High-priority test targets:
+
+- authentication and session behavior
+- workspace membership and permissions
+- account balance recalculation
+- transaction creation, editing, deletion, and transfers
+- split logic and net balance computation
+
+## 16. Planned command surface
+
+The bootstrap should provide a stable root command interface through `make`.
+
+Preferred targets:
+
+- `make install`
+- `make dev`
+- `make up`
+- `make down`
+- `make lint`
+- `make format`
+- `make typecheck`
+- `make test`
+- `make migrate`
+
+Until implementation exists, treat these as required targets to establish.
+
+## 17. Single-test command patterns
+
+These are the expected patterns once the project is scaffolded.
+
+### Backend pytest
+
+- file: `uv run pytest backend/tests/api/test_transactions.py`
+- class: `uv run pytest backend/tests/api/test_transactions.py::TestCreateTransaction`
+- test: `uv run pytest backend/tests/api/test_transactions.py::TestCreateTransaction::test_creates_expense`
+
+### Frontend unit tests
+
+- file: `pnpm --dir frontend vitest run src/components/transaction-form.test.tsx`
+- named test: `pnpm --dir frontend vitest run src/components/transaction-form.test.tsx -t "submits equal split"`
+
+### Playwright
+
+- file: `pnpm --dir frontend playwright test tests/e2e/transactions.spec.ts`
+- named test: `pnpm --dir frontend playwright test tests/e2e/transactions.spec.ts --grep "creates shared expense"`
+
+## 18. Docker and Compose expectations
+
+Docker and Docker Compose support is mandatory.
+
+At minimum, local orchestration should support:
+
+- `frontend`
+- `backend`
+- `db`
+- `redis`
+
+Use Dockerfiles and Compose definitions that support both local development and deployment-oriented reproducibility.
+
+## 19. Issue implementation order
+
+Recommended order:
+
+1. environment/bootstrap and CI
+2. authentication and sessions
+3. workspace foundation and permissions
+4. accounts and categories
+5. transactions and transfers
+6. dashboard KPI cards
+7. shared-expense split logic and net balance
+8. post-MVP enhancements
+
+## 20. Rule about external instructions
+
+If Cursor rules or Copilot instructions are added later in:
+
+- `.cursor/rules/`
+- `.cursorrules`
+- `.github/copilot-instructions.md`
+
+they must be incorporated into this file and followed.
+
+At the time of writing, no such files exist in this repository.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,172 @@
 # shared-expenses-tracking
+
+Shared expenses tracking is a workspace-based personal finance application focused on two complementary use cases:
+
+- managing personal finances in a structured way
+- managing shared expenses with a partner, including split logic and settlement visibility
+
+The repository is currently in the pre-implementation phase. This documentation baseline defines the product scope, engineering constraints, architecture direction, and contributor workflow before application code is introduced.
+
+## Product intent
+
+The product should allow users to:
+
+- create a personal workspace or a shared workspace
+- register financial movements against real accounts and categories
+- analyze balances, income, expenses, and cash flow
+- track partner-oriented shared expenses and understand who owes whom
+
+The GitHub issue tracker in `creep1ng/shared-expenses-tracking` is the canonical source of backlog scope and feature intent.
+
+## Planned stack
+
+### Frontend
+
+- Next.js
+- TypeScript
+- Tailwind CSS
+- shadcn/ui
+- React Hook Form
+- Zod
+- TanStack Query
+- **Language: Spanish (es)**
+
+### Backend
+
+- Python 3.13
+- FastAPI
+- Pydantic v2
+- SQLAlchemy 2.x
+- Alembic
+- PostgreSQL
+- Redis
+
+### Quality and tooling
+
+- uv
+- Ruff
+- mypy
+- pytest
+- Vitest
+- Playwright
+
+### Infrastructure
+
+- Docker
+- Docker Compose
+- GitHub Actions
+
+## Architecture summary
+
+The application will be built as a monorepo with:
+
+- `frontend/` for the Next.js web application
+- `backend/` for the FastAPI API and domain logic
+- `docs/` for product, process, ADR, and architecture documentation
+
+The default deployment topology is:
+
+- same parent domain for frontend and backend
+- reverse proxy routing to the frontend and backend services
+- backend-issued secure cookie sessions
+
+Core design assumptions:
+
+- a personal workspace is implemented as a one-member workspace
+- shared finance flows build on the same workspace model
+- money is stored in integer minor units
+- business logic belongs in backend services, not in UI components
+
+## MVP scope
+
+The initial MVP is intentionally limited to the minimum feature set required to deliver real value.
+
+Included in MVP:
+
+- authentication and session management
+- personal and shared workspace onboarding
+- workspace roles and permissions
+- accounts CRUD
+- categories CRUD
+- transactions CRUD
+- transaction-to-account and transaction-to-category linkage
+- transfers between accounts
+- dashboard base KPI cards
+- basic partner split support and net balance calculation
+
+Deferred until post-MVP:
+
+- advanced metadata and receipts
+- budgets and forecasts
+- scheduled payments
+- debt tracking
+- advanced charts
+- complex split transaction segmentation
+
+Details are documented in `docs/product/scope.md`.
+
+## Documentation map
+
+- `AGENTS.md`: operating instructions for agentic contributors and implementation rules
+- `docs/product/vision.md`: product goals, target users, and constraints
+- `docs/product/scope.md`: MVP and post-MVP scope boundaries
+- `docs/product/glossary.md`: shared business vocabulary
+- `docs/process/`: workflow, DoR, DoD, and documentation standards
+- `docs/adr/`: architecture decision records
+- `docs/architecture/`: architecture overview, data model, and runtime flows
+
+## Delivery workflow
+
+This project follows GitHub Flow:
+
+- create or refine a GitHub issue first
+- branch from `main`
+- implement in a focused branch
+- update code and documentation in the same PR when required
+- merge back to `main` once checks and review are complete
+
+Every issue shares a common Definition of Done, documented in:
+
+- `AGENTS.md`
+- `docs/process/definition-of-done.md`
+
+## Implementation roadmap
+
+### Phase 0: documentation baseline
+
+- ADR process and initial foundational ADRs
+- product, workflow, and architecture docs
+- contributor guidance in `AGENTS.md`
+
+### Phase 1: platform bootstrap
+
+- monorepo scaffolding
+- Docker and Compose support
+- backend and frontend project setup
+- linting, type checking, testing, and CI
+
+### Phase 2: foundation features
+
+- authentication and sessions
+- workspace model and invitations
+- roles and permissions
+
+### Phase 3: financial ledger core
+
+- accounts
+- categories
+- transactions
+- transfers
+
+### Phase 4: shared-expense value layer
+
+- split configuration
+- net balance calculation
+- settle-up flow
+- dashboard KPI cards
+
+## Local setup status
+
+Application bootstrap has not started yet. Setup instructions will be added once the initial monorepo, Docker configuration, and command surface are implemented.
+
+Until then, this repository should be treated as a documentation-first planning baseline for the upcoming implementation.

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,56 @@
+# ADR 0001: Record architecture decisions
+
+- Status: accepted
+- Date: 2026-03-07
+
+## Context
+
+The repository is starting from a greenfield state. Major decisions about stack, architecture, auth, money handling, deployment, and workflow will shape many future issues.
+
+Without a consistent decision record, contributors and coding agents would be forced to rediscover context repeatedly, which increases drift and rework.
+
+## Decision
+
+The project will maintain Architecture Decision Records under `docs/adr/`.
+
+ADRs are required for decisions that are:
+
+- cross-cutting
+- hard to reverse
+- long-lived
+- important for future contributors to understand
+
+Each ADR should include:
+
+- title
+- status
+- date
+- context
+- decision
+- consequences
+- alternatives considered
+
+ADRs should be created or updated in the same branch as the change that introduces the decision when practical.
+
+## Consequences
+
+### Positive
+
+- architectural reasoning becomes traceable
+- future contributors can understand why the system is shaped a certain way
+- issue implementation becomes more consistent
+
+### Trade-offs
+
+- contributors must spend time documenting important decisions
+- some decisions may require updating older ADRs when superseded
+
+## Alternatives considered
+
+### Implicit decisions in PR descriptions only
+
+Rejected because PR descriptions are less durable, harder to discover, and not structured enough for long-term architecture memory.
+
+### Large architecture document without ADRs
+
+Rejected because it tends to mix current state, future plans, and historical reasoning in one place, which makes decision history harder to audit.

--- a/docs/adr/0002-choose-monorepo-fastapi-nextjs-stack.md
+++ b/docs/adr/0002-choose-monorepo-fastapi-nextjs-stack.md
@@ -1,0 +1,81 @@
+# ADR 0002: Choose monorepo FastAPI and Next.js stack
+
+- Status: accepted
+- Date: 2026-03-07
+
+## Context
+
+The product needs:
+
+- a modern web frontend with structured forms and dashboard UI
+- a backend that can safely own financial logic, validation, permissions, and session handling
+- a clean path to local development and containerized deployment
+- strong documentation, testing, and maintainability characteristics
+
+## Decision
+
+The repository will use a monorepo structure with:
+
+- `frontend/` for a Next.js application using TypeScript, Tailwind CSS, and shadcn/ui, with Spanish (es) as the default language
+- `backend/` for a FastAPI application using Python, Pydantic v2, SQLAlchemy 2.x, and Alembic
+
+Primary supporting technologies:
+
+- PostgreSQL for relational persistence
+- Redis for session support and future short-lived infrastructure concerns
+- Docker and Docker Compose for local and deployment-oriented environments
+
+## Rationale
+
+### Why Next.js + shadcn/ui
+
+- fast path to a structured web UI
+- strong support for forms, tables, and dashboard flows
+- good developer experience with TypeScript
+- shadcn/ui provides consistent, composable UI primitives without locking the project into a heavy component framework
+
+### Why FastAPI
+
+- clear API development model
+- strong typing support with Pydantic
+- suitable for structured backend services and validation-heavy workflows
+
+### Why SQLAlchemy 2.x + Alembic
+
+- mature relational modeling
+- explicit control over data access patterns
+- robust migration story for a financial domain
+
+### Why a monorepo
+
+- keeps frontend, backend, docs, and infrastructure changes aligned
+- simplifies coordinated feature delivery
+- helps agentic contributors update code and documentation together
+
+## Consequences
+
+### Positive
+
+- clear separation between frontend and backend responsibilities
+- strong typed contracts in both ecosystems
+- good support for incremental growth
+- straightforward Docker Compose local setup
+
+### Trade-offs
+
+- dual ecosystem maintenance: Python and TypeScript
+- more tooling to bootstrap initially
+
+## Alternatives considered
+
+### Single-stack full Python web app
+
+Rejected because the preferred product direction includes a modern frontend using shadcn/ui and a distinct frontend application experience.
+
+### Full-stack JavaScript/TypeScript backend
+
+Rejected because the approved backend direction is Python + FastAPI + Pydantic.
+
+### Separate repositories for frontend and backend
+
+Rejected because a monorepo better supports coordinated early-stage development, issue-driven delivery, and documentation updates.

--- a/docs/adr/0003-use-cookie-based-session-auth.md
+++ b/docs/adr/0003-use-cookie-based-session-auth.md
@@ -1,0 +1,54 @@
+# ADR 0003: Use cookie-based session authentication
+
+- Status: accepted
+- Date: 2026-03-07
+
+## Context
+
+The application is browser-first and will be deployed using a same-parent-domain model with reverse-proxied frontend and backend services.
+
+The system needs secure authentication behavior suitable for workspace-scoped financial data, while keeping the frontend implementation straightforward.
+
+## Decision
+
+The backend will use email/password authentication with backend-issued secure session cookies.
+
+Planned characteristics:
+
+- `HttpOnly` cookies
+- `Secure` flag in appropriate environments
+- `SameSite=Lax` by default unless a stronger requirement emerges
+- server-managed session lifecycle
+- Redis-backed session storage by default
+
+The frontend will rely on backend session state rather than storing auth tokens in local storage.
+
+## Rationale
+
+- session cookies fit a browser-first app well
+- backend-managed sessions simplify logout, revocation, and permission enforcement
+- secure cookies reduce exposure compared with local storage token patterns
+- the chosen deployment model makes cookie auth operationally simple
+
+## Consequences
+
+### Positive
+
+- safer default auth posture
+- simpler frontend auth handling
+- better fit for protected financial flows
+
+### Trade-offs
+
+- requires careful cookie and proxy configuration
+- requires session storage strategy and lifecycle management
+
+## Alternatives considered
+
+### JWT stored in local storage
+
+Rejected as the default because it increases exposure in browser environments and shifts more auth responsibility to the client.
+
+### Third-party auth provider as the initial default
+
+Deferred. A third-party provider may be adopted later if requirements justify it, but it is not required for the MVP foundation.

--- a/docs/adr/0004-store-money-in-integer-minor-units.md
+++ b/docs/adr/0004-store-money-in-integer-minor-units.md
@@ -1,0 +1,50 @@
+# ADR 0004: Store money in integer minor units
+
+- Status: accepted
+- Date: 2026-03-07
+
+## Context
+
+The application manages balances, expenses, transfers, and split calculations. Financial values must remain stable and predictable across storage, calculations, APIs, and presentation.
+
+Using floating-point values for persisted money introduces avoidable precision and rounding risk.
+
+## Decision
+
+Persist monetary values in integer minor units.
+
+Examples:
+
+- `$10.50` becomes `1050` minor units
+- currency remains explicit and separate from numeric storage
+
+Formatting into user-facing decimal strings should happen at the API or UI presentation boundary, not in persistent storage.
+
+## Rationale
+
+- integer storage avoids floating-point precision errors
+- split logic and balance math become easier to reason about
+- financial invariants are easier to test
+
+## Consequences
+
+### Positive
+
+- stable calculations
+- simpler testing for exact balance results
+- clearer backend domain rules
+
+### Trade-offs
+
+- developers must remember to convert at boundaries
+- UI and API formatting logic must be explicit
+
+## Alternatives considered
+
+### Floating-point values
+
+Rejected because they are a poor fit for financial persistence and exact arithmetic.
+
+### Decimal storage as the default application representation
+
+Possible in some systems, but integer minor units are simpler and more consistent for the planned architecture and API boundaries.

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -1,0 +1,196 @@
+# Data Model
+
+## Data model intent
+
+The initial schema must support:
+
+- secure user access
+- personal and shared workspaces
+- workspace membership and permissions
+- account-based financial tracking
+- categorized transactions
+- future-safe shared-expense splitting
+
+## Core entities
+
+### users
+
+Represents an authenticated person using the system.
+
+### sessions
+
+Represents authenticated session state managed by the backend.
+
+### workspaces
+
+Represents the top-level financial context.
+
+Workspace types:
+
+- personal
+- shared
+
+### workspace_members
+
+Joins users to workspaces and defines their role.
+
+Initial roles:
+
+- owner
+- member
+
+### workspace_invitations
+
+Represents the invitation flow for joining a shared workspace.
+
+### accounts
+
+Represents financial sources and destinations for money movement.
+
+Initial account types:
+
+- cash
+- bank account
+- savings account
+- credit card
+
+### categories
+
+Represents financial classifications for transactions.
+
+Initial category kinds:
+
+- income
+- expense
+
+### transactions
+
+Represents financial movements.
+
+Initial movement types:
+
+- income
+- expense
+- transfer
+
+For shared-expense support, transactions should be able to store:
+
+- payer identity
+- split configuration
+
+## Key invariants
+
+- every account belongs to a workspace
+- every category belongs to a workspace or seed-derived scope strategy
+- every transaction belongs to a workspace
+- transaction permissions derive from workspace membership
+- transfers must not count as standard income or expense in analytics
+- money values are stored in integer minor units
+
+## Initial ER diagram
+
+```mermaid
+erDiagram
+    USERS ||--o{ SESSIONS : has
+    USERS ||--o{ WORKSPACE_MEMBERS : joins
+    WORKSPACES ||--o{ WORKSPACE_MEMBERS : has
+    WORKSPACES ||--o{ WORKSPACE_INVITATIONS : issues
+    WORKSPACES ||--o{ ACCOUNTS : owns
+    WORKSPACES ||--o{ CATEGORIES : owns
+    WORKSPACES ||--o{ TRANSACTIONS : owns
+    USERS ||--o{ TRANSACTIONS : pays
+    ACCOUNTS ||--o{ TRANSACTIONS : affects
+    CATEGORIES ||--o{ TRANSACTIONS : classifies
+
+    USERS {
+        uuid id
+        string email
+        string password_hash
+        datetime created_at
+        datetime updated_at
+    }
+
+    SESSIONS {
+        uuid id
+        uuid user_id
+        string session_key
+        datetime expires_at
+        datetime created_at
+    }
+
+    WORKSPACES {
+        uuid id
+        string name
+        string type
+        datetime created_at
+        datetime updated_at
+    }
+
+    WORKSPACE_MEMBERS {
+        uuid id
+        uuid workspace_id
+        uuid user_id
+        string role
+        datetime joined_at
+    }
+
+    WORKSPACE_INVITATIONS {
+        uuid id
+        uuid workspace_id
+        string email
+        string status
+        datetime expires_at
+        datetime created_at
+    }
+
+    ACCOUNTS {
+        uuid id
+        uuid workspace_id
+        string name
+        string type
+        string currency
+        int balance_minor
+        boolean archived
+        datetime created_at
+    }
+
+    CATEGORIES {
+        uuid id
+        uuid workspace_id
+        string name
+        string type
+        string icon
+        string color
+        boolean archived
+        datetime created_at
+    }
+
+    TRANSACTIONS {
+        uuid id
+        uuid workspace_id
+        uuid account_id
+        uuid category_id
+        uuid paid_by_user_id
+        string type
+        int amount_minor
+        string currency
+        json split_config
+        datetime occurred_at
+        string description
+        datetime created_at
+        datetime updated_at
+    }
+```
+
+## Notes on future evolution
+
+Likely future schema extensions include:
+
+- credit card limit and cutoff metadata
+- receipts and attachments
+- richer transaction metadata
+- scheduled payments
+- budgets
+- settlement-specific records or derived net balance views
+
+Those additions should be layered onto the core model rather than forcing a redesign of workspace, accounts, categories, and transactions.

--- a/docs/architecture/runtime-flows.md
+++ b/docs/architecture/runtime-flows.md
@@ -1,0 +1,128 @@
+# Runtime Flows
+
+## Purpose
+
+This document captures the key end-to-end flows that define the application's behavior.
+
+At the current planning stage, these flows represent intended behavior and should be refined as implementation progresses.
+
+## 1. Sign in flow
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Frontend as Next.js Frontend
+    participant Backend as FastAPI Backend
+    participant DB as PostgreSQL
+    participant Redis as Redis
+
+    User->>Frontend: Submit email and password
+    Frontend->>Backend: POST /auth/login
+    Backend->>DB: Validate user credentials
+    Backend->>Redis: Create session record
+    Backend-->>Frontend: Set secure session cookie
+    Frontend-->>User: Redirect to workspace selection or dashboard
+```
+
+## 2. Workspace onboarding flow
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Frontend as Next.js Frontend
+    participant Backend as FastAPI Backend
+    participant DB as PostgreSQL
+
+    User->>Frontend: Choose personal or shared workspace
+    Frontend->>Backend: POST /workspaces
+    Backend->>DB: Create workspace
+    Backend->>DB: Create owner membership
+    Backend-->>Frontend: Return workspace data
+    Frontend-->>User: Show workspace home
+```
+
+## 3. Transaction creation flow
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Frontend as Next.js Frontend
+    participant Backend as FastAPI Backend
+    participant DB as PostgreSQL
+
+    User->>Frontend: Submit transaction form
+    Frontend->>Backend: POST /transactions
+    Backend->>Backend: Validate session and workspace access
+    Backend->>Backend: Validate account and category
+    Backend->>Backend: Apply transaction business rules
+    Backend->>DB: Persist transaction
+    Backend->>DB: Recalculate affected account balance
+    Backend-->>Frontend: Return created transaction and updated state
+    Frontend-->>User: Show success and refreshed list/KPIs
+```
+
+## 4. Shared expense split flow
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Frontend as Next.js Frontend
+    participant Backend as FastAPI Backend
+    participant DB as PostgreSQL
+
+    User->>Frontend: Create shared expense with split config
+    Frontend->>Backend: POST /transactions with paid_by_user_id and split_config
+    Backend->>Backend: Validate workspace membership and split rules
+    Backend->>DB: Persist transaction
+    Backend->>Backend: Recompute workspace net balance
+    Backend-->>Frontend: Return transaction and net balance summary
+    Frontend-->>User: Show updated shared balance widget
+```
+
+## 5. Settle-up flow
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Frontend as Next.js Frontend
+    participant Backend as FastAPI Backend
+    participant DB as PostgreSQL
+
+    User->>Frontend: Trigger settle-up action
+    Frontend->>Backend: POST /workspaces/{id}/settlements
+    Backend->>Backend: Validate workspace role and current balance state
+    Backend->>Backend: Create settlement movement or equivalent ledger effect
+    Backend->>DB: Persist settlement result
+    Backend->>Backend: Recompute net balance
+    Backend-->>Frontend: Return updated balance state
+    Frontend-->>User: Display cleared or reduced net balance
+```
+
+## Flow design notes
+
+### Authentication
+
+- session behavior is backend-owned
+- the frontend should not be treated as the source of auth truth
+
+### Financial correctness
+
+- balance updates must happen as part of validated backend workflows
+- split calculations must be deterministic and testable
+- transfer logic must stay isolated from regular income/expense analytics
+
+### Permissions
+
+- all protected actions must validate workspace membership
+- owner/member behavior must be enforced by the backend
+
+## Future runtime flows to add
+
+As new features are introduced, add sequence or flow diagrams for:
+
+- invitation acceptance
+- password reset
+- receipt upload
+- scheduled payment generation
+- budget status recomputation
+- forecast generation

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -1,0 +1,114 @@
+# System Overview
+
+## Overview
+
+The system is planned as a workspace-based finance application composed of a separate frontend and backend within a single repository.
+
+Key properties:
+
+- browser-first web application
+- same parent domain deployment model
+- reverse-proxied frontend and backend
+- backend-owned auth, business logic, and persistence
+- workspace-first domain model for both personal and shared use
+
+## Architectural goals
+
+- keep business logic centralized in the backend
+- keep UI focused on input, presentation, and user workflows
+- make local development and deployment reproducible with Docker Compose
+- make architecture decisions explicit through ADRs and Mermaid docs
+
+## C4-style context diagram
+
+```mermaid
+flowchart LR
+    user[User] --> web[Shared Expenses Tracking Web App]
+    web --> api[Backend API]
+    api --> db[(PostgreSQL)]
+    api --> redis[(Redis)]
+    dev[Contributor] --> repo[GitHub Repository]
+    repo --> ci[GitHub Actions]
+```
+
+## C4-style container diagram
+
+```mermaid
+flowchart TB
+    browser[Browser]
+    proxy[Reverse Proxy / Same Parent Domain Routing]
+    frontend[Next.js Frontend\nTypeScript + shadcn/ui]
+    backend[FastAPI Backend\nPydantic + SQLAlchemy]
+    db[(PostgreSQL)]
+    redis[(Redis)]
+    docs[Docs / ADRs / Mermaid]
+
+    browser --> proxy
+    proxy --> frontend
+    proxy --> backend
+    backend --> db
+    backend --> redis
+    frontend -. consumes docs/process .-> docs
+    backend -. follows ADRs .-> docs
+```
+
+## Container responsibilities
+
+### Frontend
+
+Responsibilities:
+
+- authentication screens and workspace UI
+- account, category, and transaction flows
+- dashboard presentation
+- client-side validation and interaction logic
+- API consumption
+
+Non-responsibilities:
+
+- authoritative balance calculation
+- permission enforcement
+- core financial business rules
+
+### Backend
+
+Responsibilities:
+
+- authentication and session lifecycle
+- authorization and workspace access checks
+- transaction, account, and split domain logic
+- balance recalculation and invariants
+- persistence and data access
+- API contracts
+
+### PostgreSQL
+
+Responsibilities:
+
+- persistent relational data
+- transactional integrity
+- schema evolution via Alembic migrations
+
+### Redis
+
+Responsibilities:
+
+- session support
+- future short-lived state or caching if needed
+
+## Deployment model
+
+Default deployment assumption:
+
+- same parent domain
+- reverse proxy handling frontend/backend routing
+- backend session cookies scoped to the deployed domain
+
+This model supports secure cookie-based auth with lower frontend complexity.
+
+## Architecture boundaries
+
+- The frontend should not own financial truth.
+- The backend should not render the user interface.
+- Money calculations should remain centralized and tested.
+- Shared-expense rules should build on the workspace and transaction model, not on a parallel side system.

--- a/docs/process/definition-of-done.md
+++ b/docs/process/definition-of-done.md
@@ -1,0 +1,61 @@
+# Definition of Done
+
+The following Definition of Done applies to all issues in this repository.
+
+- [ ] Functionality: All the elements of the issue's Acceptance Criteria must be completed.
+- [ ] Code: The code works, it runs locally and it's integrated on the goal branch without breaking the system.
+- [ ] Quality: The code passes the linter, type checks and automated validations.
+- [ ] Testing coverage: There are tests according to the change and all the required tests passes the CI validation.
+- [ ] Bugs: There aren't critical bugs associated with the implementation.
+- [ ] Docs: There were updated the technical documentation, README, API contracts, diagrams or use notes if the implementation requires it.
+
+## Interpretation guidance
+
+### Functionality
+
+Acceptance criteria are mandatory, not aspirational.
+
+If the issue defines user-visible or technical requirements, they must be implemented or the issue remains incomplete.
+
+### Code
+
+The implementation must:
+
+- run locally
+- fit the approved architecture
+- avoid breaking adjacent workflows
+- integrate cleanly with the target branch
+
+### Quality
+
+Quality includes:
+
+- formatting
+- linting
+- type checking
+- schema and validation consistency
+
+### Testing coverage
+
+Tests should be proportional to the risk and scope of the change.
+
+High-risk financial logic must not rely only on manual validation.
+
+### Bugs
+
+An issue is not done if it introduces known critical defects into the primary flow.
+
+### Docs
+
+Update documentation whenever implementation affects:
+
+- product behavior
+- setup or usage
+- API contracts
+- architecture or data model
+- runtime flows
+- contributor expectations
+
+## Additional repository rule
+
+If a feature changes architecture, data schema, permissions, API behavior, or core runtime flow, the corresponding docs and Mermaid diagrams must be updated in the same branch.

--- a/docs/process/definition-of-ready.md
+++ b/docs/process/definition-of-ready.md
@@ -1,0 +1,72 @@
+# Definition of Ready
+
+An issue is ready for implementation when the problem and expected outcome are clear enough that a contributor can execute the work without inventing essential product behavior.
+
+## Required conditions
+
+- [ ] The issue explains the user or business problem.
+- [ ] The issue contains explicit Acceptance Criteria or Definition of Done items specific to the feature.
+- [ ] Dependencies on other issues or architectural work are identified.
+- [ ] The impacted domain areas are identified, such as auth, workspace, accounts, categories, transactions, split logic, dashboard, or docs.
+- [ ] Expected backend and frontend impact is known, if applicable.
+- [ ] The issue indicates whether data model, API, or permission changes are expected.
+- [ ] The documentation impact is considered.
+- [ ] It is clear whether an ADR is required.
+
+## Recommended issue structure
+
+Each implementation issue should ideally include:
+
+- problem statement
+- user story or developer need
+- acceptance criteria
+- non-goals or exclusions
+- dependencies
+- testing notes
+- documentation notes
+- ADR needed: yes or no
+
+## Questions to answer before implementation
+
+### Product clarity
+
+- What user behavior is being enabled or improved?
+- What is explicitly in scope?
+- What is explicitly out of scope?
+
+### Domain impact
+
+- Which entities or workflows are affected?
+- Does the issue alter account balance behavior?
+- Does it alter split or net balance logic?
+- Does it alter permissions?
+
+### Technical impact
+
+- Are migrations expected?
+- Are new endpoints expected?
+- Are new background tasks expected?
+- Does the issue introduce a new dependency or cross-cutting pattern?
+
+### Documentation impact
+
+- Should the README change?
+- Should product scope docs change?
+- Should architecture diagrams change?
+- Should an ADR be added?
+
+## Not ready examples
+
+An issue is not ready if it:
+
+- describes a vague idea without acceptance criteria
+- combines several unrelated features without boundaries
+- depends on unresolved architecture choices
+- requires hidden assumptions about data or permissions
+- omits critical workflow behavior for financial correctness
+
+## Rule for contributors
+
+If an issue is not ready, refine the issue or related docs before implementing the feature.
+
+Do not silently fill major product gaps with guesswork when the issue lacks sufficient definition.

--- a/docs/process/development-workflow.md
+++ b/docs/process/development-workflow.md
@@ -1,0 +1,128 @@
+# Development Workflow
+
+## Workflow model
+
+This project uses GitHub Flow.
+
+The default branch is `main`, and it should remain in a releasable state.
+
+## Core principles
+
+- start from a GitHub issue
+- work in a short-lived branch
+- keep changes focused
+- update code and docs together when required
+- merge only after validation and review
+
+## Standard feature workflow
+
+### 1. Start from an issue
+
+Before implementation begins:
+
+- confirm the issue is sufficiently defined
+- verify dependencies and scope
+- determine whether an ADR is required
+- determine which docs and diagrams are affected
+
+If the issue is not ready, refine it before coding.
+
+### 2. Create a branch from `main`
+
+Use focused branch names:
+
+- `feature/26-authentication-session-management`
+- `feature/30-transactions-crud-foundation`
+- `fix/31-transfer-balance-recalculation`
+- `docs/update-runtime-flows`
+- `adr/cookie-session-auth`
+
+### 3. Implement incrementally
+
+Implementation should:
+
+- follow the approved stack and ADRs
+- preserve a clean architecture boundary between frontend and backend
+- include tests proportional to the change
+- update documentation in the same branch when relevant
+
+### 4. Open a pull request
+
+Every PR should include:
+
+- linked issue
+- concise implementation summary
+- notes about migrations or environment changes
+- test evidence
+- documentation impact summary
+- ADR impact summary if relevant
+
+### 5. Validate before merge
+
+Before merge, ensure:
+
+- lint passes
+- type checks pass
+- automated tests pass
+- required docs are updated
+- the issue's acceptance criteria are satisfied
+
+## Issue categories
+
+Common issue types for this project:
+
+- feature
+- enhancement
+- bug
+- docs
+- tech-debt
+- spike
+- ADR decision item
+
+## Documentation in the workflow
+
+Documentation is expected to evolve with the system.
+
+Update docs when a change affects:
+
+- architecture boundaries
+- data model
+- runtime flows
+- API contracts
+- contributor workflow
+- product scope or glossary
+
+Do not postpone all docs until the end of a milestone.
+
+## ADR trigger points
+
+Create or update an ADR when a change introduces a decision that is:
+
+- structural
+- long-lived
+- cross-cutting
+- hard to reverse
+
+Examples:
+
+- auth strategy
+- money representation
+- monorepo structure
+- deployment topology
+- background processing model
+
+## Recommended PR checklist
+
+- issue linked
+- acceptance criteria satisfied
+- tests added or updated
+- lint and type checks pass
+- migrations reviewed if present
+- docs updated if behavior or architecture changed
+- ADR created or updated if needed
+
+## Release philosophy
+
+Prefer merging smaller validated increments over large multi-concern branches.
+
+The goal is to keep `main` healthy and make the implementation history easy to follow.

--- a/docs/process/documentation-standards.md
+++ b/docs/process/documentation-standards.md
@@ -1,0 +1,118 @@
+# Documentation Standards
+
+## Documentation philosophy
+
+This repository uses documentation as part of the implementation process.
+
+Docs are expected to:
+
+- clarify intent before code exists
+- explain why decisions were made
+- stay aligned with behavior as the project evolves
+- help humans and coding agents work consistently
+
+## Docs as code
+
+- Store documentation in version control with the implementation.
+- Update documentation in the same branch as the code when a change affects behavior or architecture.
+- Prefer small, focused documentation changes over large delayed updates.
+
+## Markdown conventions
+
+- Use clear section headings.
+- Prefer concise paragraphs and bullets over dense prose.
+- Keep terminology consistent with `docs/product/glossary.md`.
+- Use code fences for commands, directory trees, and configuration examples.
+
+## Mermaid conventions
+
+Mermaid is the default diagram format.
+
+Use the most appropriate type:
+
+- C4-style diagram for system boundaries and containers
+- ER diagram for entity relationships and schema views
+- sequence diagram for request and workflow interactions
+- flowchart for business or process decisions
+
+## Diagram update rules
+
+Update diagrams when:
+
+- a new container or service is introduced
+- a major runtime interaction changes
+- a data relationship changes
+- a business process gains new branches or states
+
+Keep diagrams close to the narrative that explains them.
+
+## ADR conventions
+
+Use ADRs for decisions that are hard to reverse or broadly impactful.
+
+Each ADR should contain:
+
+- title
+- status
+- date
+- context
+- decision
+- consequences
+- alternatives considered
+- related issues or PRs when relevant
+
+## Documentation locations
+
+- `README.md`: repository and project overview
+- `AGENTS.md`: contributor operating rules
+- `docs/product/`: product intent, scope, terminology
+- `docs/process/`: workflow, quality gates, standards
+- `docs/adr/`: architecture decisions
+- `docs/architecture/`: structure, data model, runtime flows
+
+## Update matrix by change type
+
+### Product capability change
+
+Update:
+
+- relevant feature or product docs
+- scope docs if MVP boundaries change
+- README if the project overview changes
+
+### Data model or schema change
+
+Update:
+
+- architecture data model doc
+- ER diagram
+- API docs if contracts change
+- ADR if the rule is architectural
+
+### Architecture or deployment change
+
+Update:
+
+- system overview
+- container diagram
+- ADR
+- README if setup or topology changes
+
+### Runtime workflow change
+
+Update:
+
+- runtime flow docs
+- sequence diagrams
+- API docs if relevant
+
+### Process or contributor rule change
+
+Update:
+
+- `AGENTS.md`
+- process docs
+
+## Quality rule
+
+If documentation is impacted by a change and not updated, the work is incomplete.

--- a/docs/product/glossary.md
+++ b/docs/product/glossary.md
@@ -1,0 +1,151 @@
+# Product Glossary
+
+## Account
+
+A financial container that holds or represents money movement.
+
+Examples:
+
+- cash
+- bank account
+- savings account
+- credit card account
+
+Accounts are the real source or destination of transactions.
+
+## Archived account
+
+An account that is no longer actively selectable for new transactions but remains visible for historical records and reporting.
+
+## Category
+
+A classification for a financial movement.
+
+Examples:
+
+- groceries
+- rent
+- salary
+- transportation
+
+Categories help organize reporting and analytics.
+
+## Archived category
+
+A category that can no longer be used for new entries by default, but remains attached to historical transactions.
+
+## Transaction
+
+A recorded financial movement affecting an account.
+
+Core transaction examples:
+
+- income
+- expense
+- transfer
+
+Transactions are the fundamental unit of the financial ledger.
+
+## Transfer
+
+A special type of transaction representing movement of money between two accounts.
+
+Transfers must not be counted as normal income or expense in analytics.
+
+## Workspace
+
+The top-level context that owns financial data.
+
+All accounts, categories, transactions, and reports belong to a workspace.
+
+## Personal workspace
+
+A workspace with a single member, used to manage finances alone.
+
+## Shared workspace
+
+A workspace with multiple members, used to manage finances collaboratively, such as with a partner.
+
+## Workspace member
+
+A user who belongs to a workspace and has a role governing access.
+
+## Owner
+
+A workspace member with elevated control, especially for settings and invitations.
+
+## Member
+
+A regular workspace participant with access to shared data according to permission rules.
+
+## Split
+
+The rule defining how the burden of a shared expense is divided between workspace members.
+
+Examples:
+
+- equal split
+- custom percentage split
+- one person paid but both share cost
+
+## Split configuration
+
+The stored data structure that explains how a shared expense should be allocated among participants.
+
+## Paid by user
+
+The workspace member who actually paid the money for a transaction.
+
+This may differ from who ultimately bears the cost.
+
+## Net balance
+
+The resulting debt or credit position between members after considering shared transactions and split rules.
+
+Typical example:
+
+- one member paid more than their fair share, so the other member owes them money
+
+## Settle up
+
+A user action that records or reflects a reimbursement intended to reduce or clear a net balance between members.
+
+## KPI
+
+Key Performance Indicator. A high-level metric displayed on the dashboard.
+
+Planned KPI examples:
+
+- total balance
+- total income
+- total expenses
+- net cash flow
+
+## Ledger
+
+The ordered financial record of accounts, transactions, and resulting balances.
+
+The ledger is the source of truth for all analysis and reporting.
+
+## Minor units
+
+The smallest persisted unit of money for a currency.
+
+Examples:
+
+- cents for USD
+- centavos for many Latin American currencies
+
+Money should be stored in integer minor units rather than floating-point values.
+
+## Acceptance Criteria
+
+The concrete list of expected outcomes defined in a GitHub issue.
+
+An issue is not complete unless its acceptance criteria are satisfied.
+
+## Definition of Done
+
+The shared quality and completion standard applied to every issue in this repository.
+
+It includes functionality, code quality, tests, bug expectations, and documentation updates.

--- a/docs/product/scope.md
+++ b/docs/product/scope.md
@@ -1,0 +1,201 @@
+# Product Scope
+
+## Scope strategy
+
+The issue tracker contains a broad product roadmap. This document defines what belongs in the MVP, what belongs immediately after the MVP, and what should remain out of scope until the financial core is stable.
+
+## MVP scope
+
+The MVP must establish a reliable financial foundation before adding advanced planning or analytics.
+
+### Included capabilities
+
+#### 1. Authentication and sessions
+
+- user registration
+- sign in and sign out
+- secure session persistence
+- protected route behavior
+- password reset flow if practical within the bootstrap window
+
+Primary issue:
+
+- `#26 Authentication and Session Management`
+
+#### 2. Workspace onboarding
+
+- create a personal workspace
+- create a shared workspace
+- invite a partner into a shared workspace
+- identify current workspace context in the UI
+
+Primary issue:
+
+- `#27 Workspace and Personal Space Onboarding`
+
+#### 3. Roles and permissions
+
+- owner and member roles
+- owner control over workspace settings and invitations
+- backend enforcement of protected actions
+
+Primary issue:
+
+- `#35 Workspace Roles and Permissions`
+
+#### 4. Accounts CRUD
+
+- create, view, edit, archive accounts
+- support cash, bank, savings, and credit card account types
+- maintain current balance semantics
+
+Primary issue:
+
+- `#28 Accounts CRUD Foundation`
+
+#### 5. Categories CRUD
+
+- create, edit, archive categories
+- preserve historical visibility of archived categories
+- prevent invalid duplicate use within the selected scope
+
+Primary issue:
+
+- `#29 Categories CRUD Foundation`
+
+#### 6. Transactions CRUD
+
+- create, view, edit, and delete transactions
+- enforce account and category linkage
+- recalculate affected balances correctly
+
+Primary issues:
+
+- `#30 Transactions CRUD Foundation`
+- `#23 Link Transactions to Accounts and Categories`
+
+#### 7. Transfers
+
+- register transfers between accounts
+- validate source and destination differences
+- exclude transfers from expense and income analytics
+
+Primary issue:
+
+- `#31 Transfers Between Accounts`
+
+#### 8. Base dashboard KPIs
+
+- total balance
+- total income for period
+- total expenses for period
+- net cash flow for period
+
+Primary issue:
+
+- `#33 Dashboard Base KPI Cards`
+
+#### 9. Shared-expense split MVP
+
+- record who paid a transaction
+- support equal or custom split rules for partner-oriented expenses
+- calculate net balance within a shared workspace
+- provide a simple settle-up flow later in MVP if feasible
+
+Primary issues:
+
+- reduced slice of `#5 Database Schema Migration for Split Logic`
+- reduced slice of `#20 Partner Split Toggle for Transactions`
+
+## Near-term post-MVP scope
+
+These items are important, but they should follow the financial core and shared-expense MVP.
+
+### History and filtering
+
+- `#32 Transaction History, Filters and Search`
+
+### Settings and preferences
+
+- `#34 Settings and Preferences`
+
+### Faster transaction entry UX
+
+- `#21 Frictionless Transaction Data Entry UX`
+
+### Advanced transaction metadata
+
+- `#24 Advanced Transaction Metadata Options`
+
+### Credit card account refinements
+
+- `#1 Decremental sum for credit cards`
+- `#13 Credit Card Available Limit Display`
+
+### Read-only dashboard enhancements
+
+- `#6 Current Balance Trend Line Chart`
+- `#7 Expenses per Category Bar Chart in Dashboard`
+- `#8 Expenses vs Earnings Comparison Line Chart`
+
+## Explicitly deferred beyond MVP
+
+The following are valid roadmap items but should be deferred until the core system is stable and tested.
+
+### Receipts and file management
+
+- `#22 Integrate Receipt Uploads into Transaction Form`
+
+### Budgets and forecasts
+
+- `#3 Budgeting module`
+- `#15 Budgeting Module with Progress Visuals`
+- `#19 Inline Budget Progress Visualization`
+- `#2 Expenses forecast`
+- `#14 Spending Trajectory Forecast Against Budget Limit`
+
+### Scheduled payments
+
+- `#18 Scheduled Subscriptions Warning`
+- `#25 Scheduled Payments Management`
+
+### Debt tracking beyond partner net balance
+
+- `#12 Localized Informal Debt Logging`
+
+### Savings goals and advanced card/debt analytics
+
+- `#10 Credit Card Debt Area Chart with Cut-off Marker`
+- `#11 Savings and Goals KPI Indicators on Dashboard`
+
+### Advanced split and segmentation workflows
+
+- `#17 Split Transaction into Multiple Segments`
+
+## Delivery sequence
+
+Recommended order:
+
+1. `#36` environment bootstrap and CI/CD
+2. `#26` authentication and sessions
+3. reduced `#5` schema foundation for workspace and split-ready transactions
+4. `#27` workspace onboarding
+5. `#35` roles and permissions
+6. `#28` accounts CRUD
+7. `#29` categories CRUD
+8. `#30` + `#23` transactions CRUD and linkage
+9. `#31` transfers
+10. `#33` dashboard KPIs
+11. reduced `#20` shared split and net balance
+12. `#32` and `#34` for usability and consistency
+
+## Product boundary rules
+
+When deciding whether a new request belongs in MVP, use these checks:
+
+- Does it strengthen ledger correctness?
+- Does it strengthen the personal/shared workspace experience?
+- Does it improve trust in balances and shared expense outcomes?
+- Can it be built without introducing major architectural complexity too early?
+
+If the answer is mostly no, it likely belongs after the MVP.

--- a/docs/product/vision.md
+++ b/docs/product/vision.md
@@ -1,0 +1,125 @@
+# Product Vision
+
+## Purpose
+
+Shared expenses tracking is intended to help users manage both personal finances and shared finances with a partner through a single workspace-oriented model.
+
+The application should make it easy to record movements, understand where money is going, and reason about shared spending without fragmenting the experience into separate tools.
+
+## Primary users
+
+### Individual user
+
+A person who wants to:
+
+- register income and expenses
+- organize finances by accounts and categories
+- view balance and cash-flow indicators
+- understand personal financial patterns over time
+
+### Couple or partner-based users
+
+Two people who want to:
+
+- maintain a shared financial workspace
+- register shared expenses clearly
+- identify who paid and how the expense should be split
+- understand net balances between them
+- avoid ambiguity about reimbursements and settlements
+
+## Core product promise
+
+The product should provide a trustworthy financial ledger that supports:
+
+- real accounts as sources and destinations of money
+- explicit transaction modeling
+- structured categories
+- clean reporting boundaries for income, expenses, and transfers
+- shared-expense logic built into the same ledger model
+
+## Differentiator
+
+The main product differentiator is not generic expense logging by itself. The differentiator is the combination of:
+
+- personal and shared workspaces in one model
+- accurate transaction tracking against accounts
+- partner-oriented split logic
+- visibility into net balances and settlement needs
+
+## Product principles
+
+### Workspace-first model
+
+All financial data lives in a workspace context.
+
+- a personal workspace is a workspace with one member
+- a shared workspace is a workspace with multiple members
+
+This keeps the model consistent and reduces future branching complexity.
+
+### Ledger before analytics
+
+Analytics are only trustworthy if the underlying ledger is consistent.
+
+For that reason, the product should first ensure correctness in:
+
+- account balances
+- transaction linkage
+- transfer behavior
+- shared split behavior
+
+Only then should richer charts, forecasts, and planning features be layered on top.
+
+### Explicit over implicit
+
+Financial behavior should be explicit in the data model and UI.
+
+Examples:
+
+- transfers are not normal expenses
+- split rules should be visible and intentional
+- ownership and access must be enforced by workspace membership
+
+### Auditability and trust
+
+The application should prioritize clear domain behavior over hidden automation.
+
+Users should be able to understand:
+
+- what happened
+- which account was affected
+- which category was assigned
+- who paid
+- how the cost burden was split
+- why a balance or net debt changed
+
+## Success criteria for the MVP
+
+The MVP is successful if a user can:
+
+- sign up and sign in securely
+- create a personal or shared workspace
+- create accounts and categories
+- record transactions and transfers correctly
+- see updated balances and basic KPIs
+- register a shared expense and understand who owes whom
+
+## Constraints
+
+- The system must be designed for future growth but implemented incrementally.
+- The project should support local development and deployment with Docker and Docker Compose.
+- The project must use GitHub Flow and issue-driven implementation.
+- Documentation, ADRs, and Mermaid diagrams are first-class artifacts.
+
+## Non-goals for the initial release
+
+The following are not required for the first usable version:
+
+- complex itemized split transactions
+- rich budget forecasting
+- receipt storage workflows
+- scheduled payment automation
+- advanced debt tracking beyond partner net balance
+- elaborate dashboard charts
+
+Those features remain valid roadmap candidates, but they should not compromise the delivery of a reliable core ledger and shared-expense workflow.


### PR DESCRIPTION
Establish the repository documentation baseline before implementation starts.

Expand the README with product intent, planned stack, architecture direction, MVP scope, workflow, and roadmap. Add AGENTS.md and the docs structure to define contributor rules, process expectations, and foundational product and architecture references.