### PR TITLE
feat: implement accounts and categories CRUD foundation (#28, #29)

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -39,7 +39,7 @@ Auth-related environment defaults:
 
 ## Implemented workspace API
 
-- `POST /api/v1/workspaces`: create a personal or shared workspace and owner membership for the creator
+- `POST /api/v1/workspaces`: create a personal or shared workspace, owner membership, and default workspace categories for the creator
 - `GET /api/v1/workspaces`: list the authenticated user's workspaces with their current role and member count
 - `GET /api/v1/workspaces/{workspace_id}`: return workspace details for a member
 - `PATCH /api/v1/workspaces/{workspace_id}`: update workspace name; owner only
@@ -49,11 +49,31 @@ Auth-related environment defaults:
 - `POST /api/v1/workspaces/{workspace_id}/invitations/{invitation_id}/revoke`: revoke a pending invitation; owner only
 - `POST /api/v1/workspaces/invitations/accept`: accept an invitation token and create a member membership
 
+## Implemented account API
+
+- `POST /api/v1/workspaces/{workspace_id}/accounts`: create a workspace-scoped account for any workspace member
+- `GET /api/v1/workspaces/{workspace_id}/accounts`: list active accounts with current balance for any workspace member
+- `PATCH /api/v1/workspaces/{workspace_id}/accounts/{account_id}`: update an active account for any workspace member
+- `POST /api/v1/workspaces/{workspace_id}/accounts/{account_id}/archive`: archive an account without deleting history for any workspace member
+
+## Implemented category API
+
+- `POST /api/v1/workspaces/{workspace_id}/categories`: create a workspace-scoped category for any workspace member
+- `GET /api/v1/workspaces/{workspace_id}/categories`: list active categories by default for any workspace member
+- `PATCH /api/v1/workspaces/{workspace_id}/categories/{category_id}`: update an active category for any workspace member
+- `POST /api/v1/workspaces/{workspace_id}/categories/{category_id}/archive`: archive a category without deleting history for any workspace member
+
 Implementation notes:
 
 - session records are stored in Redis with a sliding TTL
 - users and password reset tokens are stored in PostgreSQL
 - workspaces, memberships, and invitations are stored in PostgreSQL
+- accounts are stored in PostgreSQL and scoped to a workspace
+- account names are unique per workspace only while active; archived names can be reused
+- account balances are stored in integer minor units and `current_balance_minor` initially mirrors `initial_balance_minor`
+- categories are stored in PostgreSQL and scoped to a workspace
+- category names are unique per workspace and category type only while active; archived names can be reused
+- new workspaces automatically receive a default category set, and the same seed logic is reused as an idempotent backfill path for older workspaces
 - password hashes use PBKDF2-SHA256 with a configured pepper
 - reset tokens are stored hashed and, in development/test, the plaintext token is included in the response for local workflows
 - invitation tokens are stored hashed and, in development/test, the plaintext token is included in the invitation creation response for local workflows

--- a/backend/alembic/versions/20260308_000004_accounts_foundation.py
+++ b/backend/alembic/versions/20260308_000004_accounts_foundation.py
@@ -1,0 +1,74 @@
+"""accounts foundation
+
+Revision ID: 20260308_000004
+Revises: 20260308_000003
+Create Date: 2026-03-08 00:00:04
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "20260308_000004"
+down_revision = "20260308_000003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "accounts",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("workspace_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("name", sa.String(length=120), nullable=False),
+        sa.Column(
+            "type",
+            sa.Enum(
+                "cash",
+                "bank_account",
+                "savings_account",
+                "credit_card",
+                name="account_type",
+                native_enum=False,
+            ),
+            nullable=False,
+        ),
+        sa.Column("currency", sa.String(length=3), nullable=False),
+        sa.Column("initial_balance_minor", sa.BigInteger(), nullable=False),
+        sa.Column("current_balance_minor", sa.BigInteger(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+        ),
+        sa.ForeignKeyConstraint(
+            ["workspace_id"],
+            ["workspaces.id"],
+            name=op.f("fk_accounts_workspace_id_workspaces"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_accounts")),
+    )
+    op.create_index(op.f("ix_accounts_workspace_id"), "accounts", ["workspace_id"], unique=False)
+    op.create_index(op.f("ix_accounts_archived_at"), "accounts", ["archived_at"], unique=False)
+    op.create_index(
+        "uq_accounts_workspace_id_active_name",
+        "accounts",
+        ["workspace_id", sa.text("lower(name)")],
+        unique=True,
+        postgresql_where=sa.text("archived_at IS NULL"),
+        sqlite_where=sa.text("archived_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_accounts_workspace_id_active_name", table_name="accounts")
+    op.drop_index(op.f("ix_accounts_archived_at"), table_name="accounts")
+    op.drop_index(op.f("ix_accounts_workspace_id"), table_name="accounts")
+    op.drop_table("accounts")

--- a/backend/alembic/versions/20260308_000005_categories_foundation.py
+++ b/backend/alembic/versions/20260308_000005_categories_foundation.py
@@ -1,0 +1,146 @@
+"""categories foundation
+
+Revision ID: 20260308_000005
+Revises: 20260308_000004
+Create Date: 2026-03-08 00:00:05
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "20260308_000005"
+down_revision = "20260308_000004"
+branch_labels = None
+depends_on = None
+
+
+DEFAULT_CATEGORIES: tuple[dict[str, str], ...] = (
+    {"name": "Comida", "type": "expense", "icon": "utensils-crossed", "color": "#D97706"},
+    {"name": "Compras", "type": "expense", "icon": "shopping-bag", "color": "#DB2777"},
+    {"name": "Hogar", "type": "expense", "icon": "house", "color": "#2563EB"},
+    {"name": "Transporte", "type": "expense", "icon": "car-front", "color": "#0891B2"},
+    {"name": "Salud", "type": "expense", "icon": "heart-pulse", "color": "#DC2626"},
+    {"name": "Entretenimiento", "type": "expense", "icon": "film", "color": "#7C3AED"},
+    {"name": "Servicios", "type": "expense", "icon": "receipt-text", "color": "#4B5563"},
+    {"name": "Gastos financieros", "type": "expense", "icon": "landmark", "color": "#0F766E"},
+    {"name": "Salario", "type": "income", "icon": "briefcase-business", "color": "#15803D"},
+    {"name": "Freelance", "type": "income", "icon": "laptop-minimal", "color": "#16A34A"},
+    {"name": "Inversiones", "type": "income", "icon": "chart-column", "color": "#65A30D"},
+    {"name": "Otros ingresos", "type": "income", "icon": "wallet", "color": "#059669"},
+)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "categories",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("workspace_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("name", sa.String(length=120), nullable=False),
+        sa.Column(
+            "type",
+            sa.Enum("income", "expense", name="category_type", native_enum=False),
+            nullable=False,
+        ),
+        sa.Column("icon", sa.String(length=64), nullable=False),
+        sa.Column("color", sa.String(length=32), nullable=False),
+        sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+        ),
+        sa.ForeignKeyConstraint(
+            ["workspace_id"],
+            ["workspaces.id"],
+            name=op.f("fk_categories_workspace_id_workspaces"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_categories")),
+    )
+    op.create_index(
+        op.f("ix_categories_workspace_id"),
+        "categories",
+        ["workspace_id"],
+        unique=False,
+    )
+    op.create_index(op.f("ix_categories_archived_at"), "categories", ["archived_at"], unique=False)
+    op.create_index(
+        "uq_categories_workspace_id_type_active_name",
+        "categories",
+        ["workspace_id", "type", sa.text("lower(name)")],
+        unique=True,
+        postgresql_where=sa.text("archived_at IS NULL"),
+        sqlite_where=sa.text("archived_at IS NULL"),
+    )
+
+    connection = op.get_bind()
+    now = datetime.now(UTC)
+    workspace_ids = [
+        row[0] for row in connection.execute(sa.text("SELECT id FROM workspaces")).all()
+    ]
+    for category in DEFAULT_CATEGORIES:
+        for workspace_id in workspace_ids:
+            exists = connection.execute(
+                sa.text(
+                    """
+                    SELECT 1
+                    FROM categories
+                    WHERE workspace_id = :workspace_id
+                      AND type = :type
+                      AND lower(name) = lower(:name)
+                    """
+                ),
+                {"workspace_id": workspace_id, **category},
+            ).first()
+            if exists is not None:
+                continue
+
+            connection.execute(
+                sa.text(
+                    """
+                    INSERT INTO categories (
+                        id,
+                        workspace_id,
+                        name,
+                        type,
+                        icon,
+                        color,
+                        archived_at,
+                        created_at,
+                        updated_at
+                    ) VALUES (
+                        :id,
+                        :workspace_id,
+                        :name,
+                        :type,
+                        :icon,
+                        :color,
+                        NULL,
+                        :created_at,
+                        :updated_at
+                    )
+                    """
+                ),
+                {
+                    "id": uuid4(),
+                    "workspace_id": workspace_id,
+                    "created_at": now,
+                    "updated_at": now,
+                    **category,
+                },
+            )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_categories_workspace_id_type_active_name", table_name="categories")
+    op.drop_index(op.f("ix_categories_archived_at"), table_name="categories")
+    op.drop_index(op.f("ix_categories_workspace_id"), table_name="categories")
+    op.drop_table("categories")

--- a/backend/src/app/api/dependencies/accounts.py
+++ b/backend/src/app/api/dependencies/accounts.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from fastapi import Depends
+from sqlalchemy.orm import Session
+
+from app.api.dependencies.workspaces import get_workspace_service
+from app.db.session import get_db_session
+from app.services.accounts import AccountService
+from app.services.workspaces import WorkspaceService
+
+
+def get_account_service(
+    session: Session = Depends(get_db_session),
+    workspace_service: WorkspaceService = Depends(get_workspace_service),
+) -> AccountService:
+    return AccountService(session=session, workspace_service=workspace_service)

--- a/backend/src/app/api/dependencies/categories.py
+++ b/backend/src/app/api/dependencies/categories.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from fastapi import Depends
+from sqlalchemy.orm import Session
+
+from app.api.dependencies.workspaces import get_workspace_service
+from app.db.session import get_db_session
+from app.services.categories import CategoryService
+from app.services.workspaces import WorkspaceService
+
+
+def get_category_service(
+    session: Session = Depends(get_db_session),
+    workspace_service: WorkspaceService = Depends(get_workspace_service),
+) -> CategoryService:
+    return CategoryService(session=session, workspace_service=workspace_service)

--- a/backend/src/app/api/routes/accounts.py
+++ b/backend/src/app/api/routes/accounts.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query, status
+
+from app.api.dependencies.accounts import get_account_service
+from app.api.dependencies.auth import get_current_user
+from app.db.models import Account, User
+from app.schemas.accounts import (
+    AccountCreateRequest,
+    AccountListResponse,
+    AccountResponse,
+    AccountUpdateRequest,
+)
+from app.services.accounts import AccountService
+
+router = APIRouter(prefix="/workspaces/{workspace_id}/accounts", tags=["accounts"])
+
+
+@router.post("", response_model=AccountResponse, status_code=status.HTTP_201_CREATED)
+def create_account(
+    workspace_id: UUID,
+    payload: AccountCreateRequest,
+    current_user: User = Depends(get_current_user),
+    account_service: AccountService = Depends(get_account_service),
+) -> AccountResponse:
+    account = account_service.create_account(
+        workspace_id=workspace_id,
+        current_user=current_user,
+        name=payload.name,
+        account_type=payload.type,
+        currency=payload.currency,
+        initial_balance_minor=payload.initial_balance_minor,
+        description=payload.description,
+    )
+    return _build_account_response(account)
+
+
+@router.get("", response_model=AccountListResponse)
+def list_accounts(
+    workspace_id: UUID,
+    include_archived: bool = Query(default=False),
+    current_user: User = Depends(get_current_user),
+    account_service: AccountService = Depends(get_account_service),
+) -> AccountListResponse:
+    accounts = account_service.list_accounts(
+        workspace_id=workspace_id,
+        current_user=current_user,
+        include_archived=include_archived,
+    )
+    return AccountListResponse(accounts=[_build_account_response(account) for account in accounts])
+
+
+@router.patch("/{account_id}", response_model=AccountResponse)
+def update_account(
+    workspace_id: UUID,
+    account_id: UUID,
+    payload: AccountUpdateRequest,
+    current_user: User = Depends(get_current_user),
+    account_service: AccountService = Depends(get_account_service),
+) -> AccountResponse:
+    account = account_service.update_account(
+        workspace_id=workspace_id,
+        account_id=account_id,
+        current_user=current_user,
+        updates=payload.model_dump(exclude_unset=True),
+    )
+    return _build_account_response(account)
+
+
+@router.post("/{account_id}/archive", response_model=AccountResponse)
+def archive_account(
+    workspace_id: UUID,
+    account_id: UUID,
+    current_user: User = Depends(get_current_user),
+    account_service: AccountService = Depends(get_account_service),
+) -> AccountResponse:
+    account = account_service.archive_account(
+        workspace_id=workspace_id,
+        account_id=account_id,
+        current_user=current_user,
+    )
+    return _build_account_response(account)
+
+
+def _build_account_response(account: Account) -> AccountResponse:
+    return AccountResponse.model_validate(account)

--- a/backend/src/app/api/routes/categories.py
+++ b/backend/src/app/api/routes/categories.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query, status
+
+from app.api.dependencies.auth import get_current_user
+from app.api.dependencies.categories import get_category_service
+from app.db.models import Category, User
+from app.schemas.categories import (
+    CategoryCreateRequest,
+    CategoryListResponse,
+    CategoryResponse,
+    CategoryUpdateRequest,
+)
+from app.services.categories import CategoryService
+
+router = APIRouter(prefix="/workspaces/{workspace_id}/categories", tags=["categories"])
+
+
+@router.post("", response_model=CategoryResponse, status_code=status.HTTP_201_CREATED)
+def create_category(
+    workspace_id: UUID,
+    payload: CategoryCreateRequest,
+    current_user: User = Depends(get_current_user),
+    category_service: CategoryService = Depends(get_category_service),
+) -> CategoryResponse:
+    category = category_service.create_category(
+        workspace_id=workspace_id,
+        current_user=current_user,
+        name=payload.name,
+        category_type=payload.type,
+        icon=payload.icon,
+        color=payload.color,
+    )
+    return _build_category_response(category)
+
+
+@router.get("", response_model=CategoryListResponse)
+def list_categories(
+    workspace_id: UUID,
+    include_archived: bool = Query(default=False),
+    current_user: User = Depends(get_current_user),
+    category_service: CategoryService = Depends(get_category_service),
+) -> CategoryListResponse:
+    categories = category_service.list_categories(
+        workspace_id=workspace_id,
+        current_user=current_user,
+        include_archived=include_archived,
+    )
+    return CategoryListResponse(
+        categories=[_build_category_response(category) for category in categories]
+    )
+
+
+@router.patch("/{category_id}", response_model=CategoryResponse)
+def update_category(
+    workspace_id: UUID,
+    category_id: UUID,
+    payload: CategoryUpdateRequest,
+    current_user: User = Depends(get_current_user),
+    category_service: CategoryService = Depends(get_category_service),
+) -> CategoryResponse:
+    category = category_service.update_category(
+        workspace_id=workspace_id,
+        category_id=category_id,
+        current_user=current_user,
+        updates=payload.model_dump(exclude_unset=True),
+    )
+    return _build_category_response(category)
+
+
+@router.post("/{category_id}/archive", response_model=CategoryResponse)
+def archive_category(
+    workspace_id: UUID,
+    category_id: UUID,
+    current_user: User = Depends(get_current_user),
+    category_service: CategoryService = Depends(get_category_service),
+) -> CategoryResponse:
+    category = category_service.archive_category(
+        workspace_id=workspace_id,
+        category_id=category_id,
+        current_user=current_user,
+    )
+    return _build_category_response(category)
+
+
+def _build_category_response(category: Category) -> CategoryResponse:
+    return CategoryResponse.model_validate(category)

--- a/backend/src/app/db/models.py
+++ b/backend/src/app/db/models.py
@@ -5,9 +5,11 @@ from enum import Enum
 from uuid import UUID, uuid4
 
 from sqlalchemy import (
+    BigInteger,
     Boolean,
     DateTime,
     ForeignKey,
+    Index,
     String,
     Text,
     UniqueConstraint,
@@ -51,6 +53,18 @@ class WorkspaceInvitationStatus(str, Enum):
     ACCEPTED = "accepted"
     REVOKED = "revoked"
     EXPIRED = "expired"
+
+
+class AccountType(str, Enum):
+    CASH = "cash"
+    BANK_ACCOUNT = "bank_account"
+    SAVINGS_ACCOUNT = "savings_account"
+    CREDIT_CARD = "credit_card"
+
+
+class CategoryType(str, Enum):
+    INCOME = "income"
+    EXPENSE = "expense"
 
 
 class User(TimestampMixin, Base):
@@ -135,6 +149,14 @@ class Workspace(TimestampMixin, Base):
         cascade="all, delete-orphan",
     )
     invitations: Mapped[list[WorkspaceInvitation]] = relationship(
+        back_populates="workspace",
+        cascade="all, delete-orphan",
+    )
+    accounts: Mapped[list[Account]] = relationship(
+        back_populates="workspace",
+        cascade="all, delete-orphan",
+    )
+    categories: Mapped[list[Category]] = relationship(
         back_populates="workspace",
         cascade="all, delete-orphan",
     )
@@ -228,3 +250,94 @@ class WorkspaceInvitation(TimestampMixin, Base):
         back_populates="accepted_workspace_invitations",
         foreign_keys=[accepted_by_user_id],
     )
+
+
+class Account(TimestampMixin, Base):
+    __tablename__ = "accounts"
+
+    id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True, default=uuid4)
+    workspace_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    type: Mapped[AccountType] = mapped_column(
+        SAEnum(
+            AccountType,
+            name="account_type",
+            native_enum=False,
+            values_callable=lambda enum_class: [item.value for item in enum_class],
+        ),
+        nullable=False,
+    )
+    currency: Mapped[str] = mapped_column(String(3), nullable=False)
+    initial_balance_minor: Mapped[int] = mapped_column(BigInteger(), nullable=False)
+    current_balance_minor: Mapped[int] = mapped_column(BigInteger(), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    archived_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, index=True
+    )
+
+    __table_args__ = (
+        Index(
+            "uq_accounts_workspace_id_active_name",
+            "workspace_id",
+            func.lower(name),
+            unique=True,
+            postgresql_where=archived_at.is_(None),
+            sqlite_where=archived_at.is_(None),
+        ),
+    )
+
+    workspace: Mapped[Workspace] = relationship(back_populates="accounts")
+
+    @property
+    def is_archived(self) -> bool:
+        return self.archived_at is not None
+
+
+class Category(TimestampMixin, Base):
+    __tablename__ = "categories"
+
+    id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True, default=uuid4)
+    workspace_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    type: Mapped[CategoryType] = mapped_column(
+        SAEnum(
+            CategoryType,
+            name="category_type",
+            native_enum=False,
+            values_callable=lambda enum_class: [item.value for item in enum_class],
+        ),
+        nullable=False,
+    )
+    icon: Mapped[str] = mapped_column(String(64), nullable=False)
+    color: Mapped[str] = mapped_column(String(32), nullable=False)
+    archived_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, index=True
+    )
+
+    __table_args__ = (
+        Index(
+            "uq_categories_workspace_id_type_active_name",
+            "workspace_id",
+            "type",
+            func.lower(name),
+            unique=True,
+            postgresql_where=archived_at.is_(None),
+            sqlite_where=archived_at.is_(None),
+        ),
+    )
+
+    workspace: Mapped[Workspace] = relationship(back_populates="categories")
+
+    @property
+    def is_archived(self) -> bool:
+        return self.archived_at is not None

--- a/backend/src/app/main.py
+++ b/backend/src/app/main.py
@@ -1,7 +1,9 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.api.routes.accounts import router as accounts_router
 from app.api.routes.auth import router as auth_router
+from app.api.routes.categories import router as categories_router
 from app.api.routes.health import router as health_router
 from app.api.routes.workspaces import router as workspaces_router
 from app.core.config import Settings, get_settings
@@ -28,6 +30,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(auth_router, prefix=app_settings.api_v1_prefix)
     app.include_router(health_router, prefix=app_settings.api_v1_prefix)
     app.include_router(workspaces_router, prefix=app_settings.api_v1_prefix)
+    app.include_router(accounts_router, prefix=app_settings.api_v1_prefix)
+    app.include_router(categories_router, prefix=app_settings.api_v1_prefix)
 
     return app
 

--- a/backend/src/app/models/__init__.py
+++ b/backend/src/app/models/__init__.py
@@ -1,4 +1,8 @@
 from app.db.models import (
+    Account,
+    AccountType,
+    Category,
+    CategoryType,
     PasswordResetToken,
     User,
     Workspace,
@@ -10,6 +14,10 @@ from app.db.models import (
 )
 
 __all__ = [
+    "Account",
+    "AccountType",
+    "Category",
+    "CategoryType",
     "PasswordResetToken",
     "User",
     "Workspace",

--- a/backend/src/app/repositories/accounts.py
+++ b/backend/src/app/repositories/accounts.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import Select, func, select
+from sqlalchemy.orm import Session, joinedload
+
+from app.db.models import Account, AccountType
+
+
+class AccountRepository:
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def create(
+        self,
+        *,
+        workspace_id: UUID,
+        name: str,
+        account_type: AccountType,
+        currency: str,
+        initial_balance_minor: int,
+        description: str | None,
+    ) -> Account:
+        account = Account(
+            workspace_id=workspace_id,
+            name=name,
+            type=account_type,
+            currency=currency,
+            initial_balance_minor=initial_balance_minor,
+            current_balance_minor=initial_balance_minor,
+            description=description,
+        )
+        self._session.add(account)
+        self._session.flush()
+        self._session.refresh(account)
+        return account
+
+    def list_by_workspace(self, *, workspace_id: UUID, include_archived: bool) -> list[Account]:
+        statement = self._base_query().where(Account.workspace_id == workspace_id)
+        if not include_archived:
+            statement = statement.where(Account.archived_at.is_(None))
+        statement = statement.order_by(Account.created_at.asc())
+        return list(self._session.scalars(statement).all())
+
+    def get_by_id(self, *, workspace_id: UUID, account_id: UUID) -> Account | None:
+        statement = self._base_query().where(
+            Account.workspace_id == workspace_id,
+            Account.id == account_id,
+        )
+        return self._session.scalar(statement)
+
+    def get_active_by_name(
+        self,
+        *,
+        workspace_id: UUID,
+        name: str,
+        exclude_account_id: UUID | None = None,
+    ) -> Account | None:
+        statement = self._base_query().where(
+            Account.workspace_id == workspace_id,
+            Account.archived_at.is_(None),
+            func.lower(Account.name) == name.lower(),
+        )
+        if exclude_account_id is not None:
+            statement = statement.where(Account.id != exclude_account_id)
+        return self._session.scalar(statement)
+
+    def update(
+        self,
+        account: Account,
+        *,
+        name: str,
+        account_type: AccountType,
+        currency: str,
+        initial_balance_minor: int,
+        current_balance_minor: int,
+        description: str | None,
+    ) -> Account:
+        account.name = name
+        account.type = account_type
+        account.currency = currency
+        account.initial_balance_minor = initial_balance_minor
+        account.current_balance_minor = current_balance_minor
+        account.description = description
+        self._session.add(account)
+        self._session.flush()
+        self._session.refresh(account)
+        return account
+
+    def archive(self, account: Account, *, archived_at: datetime) -> Account:
+        account.archived_at = archived_at
+        self._session.add(account)
+        self._session.flush()
+        self._session.refresh(account)
+        return account
+
+    @staticmethod
+    def _base_query() -> Select[tuple[Account]]:
+        return select(Account).options(joinedload(Account.workspace))

--- a/backend/src/app/repositories/categories.py
+++ b/backend/src/app/repositories/categories.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import Select, func, select
+from sqlalchemy.orm import Session, joinedload
+
+from app.db.models import Category, CategoryType
+
+
+@dataclass(frozen=True)
+class DefaultCategorySeed:
+    name: str
+    category_type: CategoryType
+    icon: str
+    color: str
+
+
+DEFAULT_WORKSPACE_CATEGORY_SEEDS: tuple[DefaultCategorySeed, ...] = (
+    DefaultCategorySeed(
+        name="Comida",
+        category_type=CategoryType.EXPENSE,
+        icon="utensils-crossed",
+        color="#D97706",
+    ),
+    DefaultCategorySeed(
+        name="Compras",
+        category_type=CategoryType.EXPENSE,
+        icon="shopping-bag",
+        color="#DB2777",
+    ),
+    DefaultCategorySeed(
+        name="Hogar",
+        category_type=CategoryType.EXPENSE,
+        icon="house",
+        color="#2563EB",
+    ),
+    DefaultCategorySeed(
+        name="Transporte",
+        category_type=CategoryType.EXPENSE,
+        icon="car-front",
+        color="#0891B2",
+    ),
+    DefaultCategorySeed(
+        name="Salud",
+        category_type=CategoryType.EXPENSE,
+        icon="heart-pulse",
+        color="#DC2626",
+    ),
+    DefaultCategorySeed(
+        name="Entretenimiento",
+        category_type=CategoryType.EXPENSE,
+        icon="film",
+        color="#7C3AED",
+    ),
+    DefaultCategorySeed(
+        name="Servicios",
+        category_type=CategoryType.EXPENSE,
+        icon="receipt-text",
+        color="#4B5563",
+    ),
+    DefaultCategorySeed(
+        name="Gastos financieros",
+        category_type=CategoryType.EXPENSE,
+        icon="landmark",
+        color="#0F766E",
+    ),
+    DefaultCategorySeed(
+        name="Salario",
+        category_type=CategoryType.INCOME,
+        icon="briefcase-business",
+        color="#15803D",
+    ),
+    DefaultCategorySeed(
+        name="Freelance",
+        category_type=CategoryType.INCOME,
+        icon="laptop-minimal",
+        color="#16A34A",
+    ),
+    DefaultCategorySeed(
+        name="Inversiones",
+        category_type=CategoryType.INCOME,
+        icon="chart-column",
+        color="#65A30D",
+    ),
+    DefaultCategorySeed(
+        name="Otros ingresos",
+        category_type=CategoryType.INCOME,
+        icon="wallet",
+        color="#059669",
+    ),
+)
+
+
+class CategoryRepository:
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def create(
+        self,
+        *,
+        workspace_id: UUID,
+        name: str,
+        category_type: CategoryType,
+        icon: str,
+        color: str,
+    ) -> Category:
+        category = Category(
+            workspace_id=workspace_id,
+            name=name,
+            type=category_type,
+            icon=icon,
+            color=color,
+        )
+        self._session.add(category)
+        self._session.flush()
+        self._session.refresh(category)
+        return category
+
+    def list_by_workspace(self, *, workspace_id: UUID, include_archived: bool) -> list[Category]:
+        statement = self._base_query().where(Category.workspace_id == workspace_id)
+        if not include_archived:
+            statement = statement.where(Category.archived_at.is_(None))
+        statement = statement.order_by(Category.type.asc(), Category.created_at.asc())
+        return list(self._session.scalars(statement).all())
+
+    def get_by_id(self, *, workspace_id: UUID, category_id: UUID) -> Category | None:
+        statement = self._base_query().where(
+            Category.workspace_id == workspace_id,
+            Category.id == category_id,
+        )
+        return self._session.scalar(statement)
+
+    def get_active_by_name(
+        self,
+        *,
+        workspace_id: UUID,
+        name: str,
+        category_type: CategoryType,
+        exclude_category_id: UUID | None = None,
+    ) -> Category | None:
+        statement = self._base_query().where(
+            Category.workspace_id == workspace_id,
+            Category.type == category_type,
+            Category.archived_at.is_(None),
+            func.lower(Category.name) == name.lower(),
+        )
+        if exclude_category_id is not None:
+            statement = statement.where(Category.id != exclude_category_id)
+        return self._session.scalar(statement)
+
+    def update(
+        self,
+        category: Category,
+        *,
+        name: str,
+        category_type: CategoryType,
+        icon: str,
+        color: str,
+    ) -> Category:
+        category.name = name
+        category.type = category_type
+        category.icon = icon
+        category.color = color
+        self._session.add(category)
+        self._session.flush()
+        self._session.refresh(category)
+        return category
+
+    def archive(self, category: Category, *, archived_at: datetime) -> Category:
+        category.archived_at = archived_at
+        self._session.add(category)
+        self._session.flush()
+        self._session.refresh(category)
+        return category
+
+    def ensure_default_categories_for_workspace(self, *, workspace_id: UUID) -> list[Category]:
+        """Seed missing defaults for a workspace.
+
+        This is intentionally idempotent so the same method can be reused during
+        workspace creation and for backfill workflows on pre-existing workspaces.
+        Any existing matching name/type pair, including archived rows, is treated
+        as already seeded so the backfill does not recreate intentionally retired
+        defaults.
+        """
+        existing_keys = {
+            (category_type, name.lower())
+            for category_type, name in self._session.execute(
+                select(Category.type, Category.name).where(Category.workspace_id == workspace_id)
+            ).all()
+        }
+
+        created_categories: list[Category] = []
+        for seed in DEFAULT_WORKSPACE_CATEGORY_SEEDS:
+            key = (seed.category_type, seed.name.lower())
+            if key in existing_keys:
+                continue
+
+            category = Category(
+                workspace_id=workspace_id,
+                name=seed.name,
+                type=seed.category_type,
+                icon=seed.icon,
+                color=seed.color,
+            )
+            self._session.add(category)
+            created_categories.append(category)
+            existing_keys.add(key)
+
+        if created_categories:
+            self._session.flush()
+            for category in created_categories:
+                self._session.refresh(category)
+
+        return created_categories
+
+    @staticmethod
+    def _base_query() -> Select[tuple[Category]]:
+        return select(Category).options(joinedload(Category.workspace))

--- a/backend/src/app/schemas/accounts.py
+++ b/backend/src/app/schemas/accounts.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.db.models import AccountType
+
+
+class AccountCreateRequest(BaseModel):
+    name: str = Field(min_length=1, max_length=120)
+    type: AccountType
+    currency: str = Field(min_length=3, max_length=3)
+    initial_balance_minor: int
+    description: str | None = Field(default=None, max_length=1000)
+
+
+class AccountUpdateRequest(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=120)
+    type: AccountType | None = None
+    currency: str | None = Field(default=None, min_length=3, max_length=3)
+    initial_balance_minor: int | None = None
+    description: str | None = Field(default=None, max_length=1000)
+
+
+class AccountResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    workspace_id: UUID
+    name: str
+    type: AccountType
+    currency: str
+    initial_balance_minor: int
+    current_balance_minor: int
+    description: str | None
+    archived_at: datetime | None
+    is_archived: bool
+    created_at: datetime
+    updated_at: datetime
+
+
+class AccountListResponse(BaseModel):
+    accounts: list[AccountResponse]

--- a/backend/src/app/schemas/categories.py
+++ b/backend/src/app/schemas/categories.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.db.models import CategoryType
+
+
+class CategoryCreateRequest(BaseModel):
+    name: str = Field(min_length=1, max_length=120)
+    type: CategoryType
+    icon: str = Field(min_length=1, max_length=64)
+    color: str = Field(min_length=1, max_length=32)
+
+
+class CategoryUpdateRequest(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=120)
+    type: CategoryType | None = None
+    icon: str | None = Field(default=None, min_length=1, max_length=64)
+    color: str | None = Field(default=None, min_length=1, max_length=32)
+
+
+class CategoryResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    workspace_id: UUID
+    name: str
+    type: CategoryType
+    icon: str
+    color: str
+    archived_at: datetime | None
+    is_archived: bool
+    created_at: datetime
+    updated_at: datetime
+
+
+class CategoryListResponse(BaseModel):
+    categories: list[CategoryResponse]

--- a/backend/src/app/services/accounts.py
+++ b/backend/src/app/services/accounts.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from fastapi import HTTPException, status
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.core.time import utc_now
+from app.db.models import Account, AccountType, User
+from app.repositories.accounts import AccountRepository
+from app.services.workspaces import WorkspaceService
+
+
+class AccountService:
+    def __init__(self, session: Session, workspace_service: WorkspaceService) -> None:
+        self._session = session
+        self._workspace_service = workspace_service
+        self._accounts = AccountRepository(session)
+
+    def create_account(
+        self,
+        *,
+        workspace_id: UUID,
+        current_user: User,
+        name: str,
+        account_type: AccountType,
+        currency: str,
+        initial_balance_minor: int,
+        description: str | None,
+    ) -> Account:
+        self._workspace_service.get_workspace_access(
+            workspace_id=workspace_id,
+            current_user=current_user,
+        )
+        normalized_name = self._normalize_name(name)
+        normalized_currency = self._normalize_currency(currency)
+        normalized_description = self._normalize_description(description)
+        self._ensure_active_name_available(workspace_id=workspace_id, name=normalized_name)
+
+        try:
+            account = self._accounts.create(
+                workspace_id=workspace_id,
+                name=normalized_name,
+                account_type=account_type,
+                currency=normalized_currency,
+                initial_balance_minor=initial_balance_minor,
+                description=normalized_description,
+            )
+            self._session.commit()
+        except IntegrityError as exc:
+            self._session.rollback()
+            if self._is_duplicate_name_error(exc):
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="An active account with that name already exists in this workspace.",
+                ) from exc
+            raise
+
+        return account
+
+    def list_accounts(
+        self,
+        *,
+        workspace_id: UUID,
+        current_user: User,
+        include_archived: bool,
+    ) -> list[Account]:
+        self._workspace_service.get_workspace_access(
+            workspace_id=workspace_id,
+            current_user=current_user,
+        )
+        return self._accounts.list_by_workspace(
+            workspace_id=workspace_id,
+            include_archived=include_archived,
+        )
+
+    def update_account(
+        self,
+        *,
+        workspace_id: UUID,
+        account_id: UUID,
+        current_user: User,
+        updates: dict[str, Any],
+    ) -> Account:
+        self._workspace_service.get_workspace_access(
+            workspace_id=workspace_id,
+            current_user=current_user,
+        )
+        account = self._get_account_or_404(workspace_id=workspace_id, account_id=account_id)
+        if account.archived_at is not None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Archived accounts cannot be updated.",
+            )
+
+        if not updates:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="At least one field must be provided.",
+            )
+
+        updated_name = (
+            self._normalize_name(str(updates["name"])) if "name" in updates else account.name
+        )
+        updated_currency = (
+            self._normalize_currency(str(updates["currency"]))
+            if "currency" in updates
+            else account.currency
+        )
+        updated_description = (
+            self._normalize_description(updates.get("description"))
+            if "description" in updates
+            else account.description
+        )
+        updated_initial_balance_minor = (
+            int(updates["initial_balance_minor"])
+            if "initial_balance_minor" in updates
+            else account.initial_balance_minor
+        )
+        updated_type = AccountType(updates["type"]) if "type" in updates else account.type
+        updated_current_balance_minor = account.current_balance_minor + (
+            updated_initial_balance_minor - account.initial_balance_minor
+        )
+        self._ensure_active_name_available(
+            workspace_id=workspace_id,
+            name=updated_name,
+            exclude_account_id=account.id,
+        )
+
+        try:
+            updated_account = self._accounts.update(
+                account,
+                name=updated_name,
+                account_type=updated_type,
+                currency=updated_currency,
+                initial_balance_minor=updated_initial_balance_minor,
+                current_balance_minor=updated_current_balance_minor,
+                description=updated_description,
+            )
+            self._session.commit()
+        except IntegrityError as exc:
+            self._session.rollback()
+            if self._is_duplicate_name_error(exc):
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="An active account with that name already exists in this workspace.",
+                ) from exc
+            raise
+
+        return updated_account
+
+    def archive_account(
+        self,
+        *,
+        workspace_id: UUID,
+        account_id: UUID,
+        current_user: User,
+    ) -> Account:
+        self._workspace_service.get_workspace_access(
+            workspace_id=workspace_id,
+            current_user=current_user,
+        )
+        account = self._get_account_or_404(workspace_id=workspace_id, account_id=account_id)
+        if account.archived_at is not None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Account has already been archived.",
+            )
+
+        archived_account = self._accounts.archive(account, archived_at=utc_now())
+        self._session.commit()
+        return archived_account
+
+    def _get_account_or_404(self, *, workspace_id: UUID, account_id: UUID) -> Account:
+        account = self._accounts.get_by_id(workspace_id=workspace_id, account_id=account_id)
+        if account is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Account not found.",
+            )
+        return account
+
+    @staticmethod
+    def _normalize_name(name: str) -> str:
+        normalized_name = name.strip()
+        if normalized_name == "":
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Account name must not be empty.",
+            )
+        return normalized_name
+
+    @staticmethod
+    def _normalize_currency(currency: str) -> str:
+        normalized_currency = currency.strip().upper()
+        if len(normalized_currency) != 3 or not normalized_currency.isalpha():
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Currency must be a 3-letter ISO code.",
+            )
+        return normalized_currency
+
+    @staticmethod
+    def _normalize_description(description: str | None) -> str | None:
+        if description is None:
+            return None
+        normalized_description = description.strip()
+        return normalized_description or None
+
+    def _ensure_active_name_available(
+        self,
+        *,
+        workspace_id: UUID,
+        name: str,
+        exclude_account_id: UUID | None = None,
+    ) -> None:
+        duplicate_account = self._accounts.get_active_by_name(
+            workspace_id=workspace_id,
+            name=name,
+            exclude_account_id=exclude_account_id,
+        )
+        if duplicate_account is not None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="An active account with that name already exists in this workspace.",
+            )
+
+    @staticmethod
+    def _is_duplicate_name_error(exc: IntegrityError) -> bool:
+        return "uq_accounts_workspace_id_active_name" in str(exc.orig)

--- a/backend/src/app/services/categories.py
+++ b/backend/src/app/services/categories.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from fastapi import HTTPException, status
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.core.time import utc_now
+from app.db.models import Category, CategoryType, User
+from app.repositories.categories import CategoryRepository
+from app.services.workspaces import WorkspaceService
+
+
+class CategoryService:
+    def __init__(self, session: Session, workspace_service: WorkspaceService) -> None:
+        self._session = session
+        self._workspace_service = workspace_service
+        self._categories = CategoryRepository(session)
+
+    DUPLICATE_ACTIVE_CATEGORY_DETAIL = (
+        "An active category with that type and name already exists in this workspace."
+    )
+
+    def create_category(
+        self,
+        *,
+        workspace_id: UUID,
+        current_user: User,
+        name: str,
+        category_type: CategoryType,
+        icon: str,
+        color: str,
+    ) -> Category:
+        self._workspace_service.get_workspace_access(
+            workspace_id=workspace_id,
+            current_user=current_user,
+        )
+        normalized_name = self._normalize_name(name)
+        normalized_icon = self._normalize_icon(icon)
+        normalized_color = self._normalize_color(color)
+        self._ensure_active_name_available(
+            workspace_id=workspace_id,
+            name=normalized_name,
+            category_type=category_type,
+        )
+
+        try:
+            category = self._categories.create(
+                workspace_id=workspace_id,
+                name=normalized_name,
+                category_type=category_type,
+                icon=normalized_icon,
+                color=normalized_color,
+            )
+            self._session.commit()
+        except IntegrityError as exc:
+            self._session.rollback()
+            if self._is_duplicate_name_error(exc):
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail=self.DUPLICATE_ACTIVE_CATEGORY_DETAIL,
+                ) from exc
+            raise
+
+        return category
+
+    def list_categories(
+        self,
+        *,
+        workspace_id: UUID,
+        current_user: User,
+        include_archived: bool,
+    ) -> list[Category]:
+        self._workspace_service.get_workspace_access(
+            workspace_id=workspace_id,
+            current_user=current_user,
+        )
+        return self._categories.list_by_workspace(
+            workspace_id=workspace_id,
+            include_archived=include_archived,
+        )
+
+    def update_category(
+        self,
+        *,
+        workspace_id: UUID,
+        category_id: UUID,
+        current_user: User,
+        updates: dict[str, Any],
+    ) -> Category:
+        self._workspace_service.get_workspace_access(
+            workspace_id=workspace_id,
+            current_user=current_user,
+        )
+        category = self._get_category_or_404(workspace_id=workspace_id, category_id=category_id)
+        if category.archived_at is not None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Archived categories cannot be updated.",
+            )
+
+        if not updates:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="At least one field must be provided.",
+            )
+
+        updated_name = (
+            self._normalize_name(str(updates["name"])) if "name" in updates else category.name
+        )
+        updated_type = CategoryType(updates["type"]) if "type" in updates else category.type
+        updated_icon = (
+            self._normalize_icon(str(updates["icon"])) if "icon" in updates else category.icon
+        )
+        updated_color = (
+            self._normalize_color(str(updates["color"])) if "color" in updates else category.color
+        )
+        self._ensure_active_name_available(
+            workspace_id=workspace_id,
+            name=updated_name,
+            category_type=updated_type,
+            exclude_category_id=category.id,
+        )
+
+        try:
+            updated_category = self._categories.update(
+                category,
+                name=updated_name,
+                category_type=updated_type,
+                icon=updated_icon,
+                color=updated_color,
+            )
+            self._session.commit()
+        except IntegrityError as exc:
+            self._session.rollback()
+            if self._is_duplicate_name_error(exc):
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail=self.DUPLICATE_ACTIVE_CATEGORY_DETAIL,
+                ) from exc
+            raise
+
+        return updated_category
+
+    def archive_category(
+        self,
+        *,
+        workspace_id: UUID,
+        category_id: UUID,
+        current_user: User,
+    ) -> Category:
+        self._workspace_service.get_workspace_access(
+            workspace_id=workspace_id,
+            current_user=current_user,
+        )
+        category = self._get_category_or_404(workspace_id=workspace_id, category_id=category_id)
+        if category.archived_at is not None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Category has already been archived.",
+            )
+
+        archived_category = self._categories.archive(category, archived_at=utc_now())
+        self._session.commit()
+        return archived_category
+
+    def _get_category_or_404(self, *, workspace_id: UUID, category_id: UUID) -> Category:
+        category = self._categories.get_by_id(workspace_id=workspace_id, category_id=category_id)
+        if category is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Category not found.",
+            )
+        return category
+
+    @staticmethod
+    def _normalize_name(name: str) -> str:
+        normalized_name = name.strip()
+        if normalized_name == "":
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Category name must not be empty.",
+            )
+        return normalized_name
+
+    @staticmethod
+    def _normalize_icon(icon: str) -> str:
+        normalized_icon = icon.strip()
+        if normalized_icon == "":
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Category icon must not be empty.",
+            )
+        return normalized_icon
+
+    @staticmethod
+    def _normalize_color(color: str) -> str:
+        normalized_color = color.strip()
+        if normalized_color == "":
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Category color must not be empty.",
+            )
+        return normalized_color
+
+    def _ensure_active_name_available(
+        self,
+        *,
+        workspace_id: UUID,
+        name: str,
+        category_type: CategoryType,
+        exclude_category_id: UUID | None = None,
+    ) -> None:
+        duplicate_category = self._categories.get_active_by_name(
+            workspace_id=workspace_id,
+            name=name,
+            category_type=category_type,
+            exclude_category_id=exclude_category_id,
+        )
+        if duplicate_category is not None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=self.DUPLICATE_ACTIVE_CATEGORY_DETAIL,
+            )
+
+    @staticmethod
+    def _is_duplicate_name_error(exc: IntegrityError) -> bool:
+        return "uq_categories_workspace_id_type_active_name" in str(exc.orig)

--- a/backend/src/app/services/workspaces.py
+++ b/backend/src/app/services/workspaces.py
@@ -20,6 +20,7 @@ from app.db.models import (
     WorkspaceType,
 )
 from app.repositories.auth import UserRepository
+from app.repositories.categories import CategoryRepository
 from app.repositories.workspaces import (
     WorkspaceInvitationRepository,
     WorkspaceMemberRepository,
@@ -47,6 +48,7 @@ class WorkspaceService:
         self._workspaces = WorkspaceRepository(session)
         self._members = WorkspaceMemberRepository(session)
         self._invitations = WorkspaceInvitationRepository(session)
+        self._categories = CategoryRepository(session)
 
     def create_workspace(
         self, *, current_user: User, name: str, workspace_type: WorkspaceType
@@ -62,6 +64,7 @@ class WorkspaceService:
             user_id=current_user.id,
             role=WorkspaceMemberRole.OWNER,
         )
+        self._categories.ensure_default_categories_for_workspace(workspace_id=workspace.id)
         self._session.commit()
         return self.get_workspace_access(
             workspace_id=workspace.id, current_user=current_user, membership=membership

--- a/backend/tests/test_accounts.py
+++ b/backend/tests/test_accounts.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from pathlib import Path
+from typing import cast
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.api.dependencies.auth import _TEST_REDIS
+from app.core.config import get_settings
+from app.db.base import Base
+from app.db.session import get_db_session
+from app.main import create_app
+
+
+@pytest.fixture
+def accounts_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient]:
+    database_path = tmp_path / "accounts.db"
+    monkeypatch.setenv("APP_ENV", "test")
+    monkeypatch.setenv("APP_DEBUG", "false")
+    monkeypatch.setenv("API_V1_PREFIX", "/api/v1")
+    monkeypatch.setenv("DATABASE_HOST", "localhost")
+    monkeypatch.setenv("DATABASE_PORT", "5432")
+    monkeypatch.setenv("DATABASE_NAME", "shared_expenses_test")
+    monkeypatch.setenv("DATABASE_USER", "postgres")
+    monkeypatch.setenv("DATABASE_PASSWORD", "postgres")
+    monkeypatch.setenv("DATABASE_ECHO", "false")
+    monkeypatch.setenv("REDIS_HOST", "localhost")
+    monkeypatch.setenv("REDIS_PORT", "6379")
+    monkeypatch.setenv("REDIS_DB", "0")
+    monkeypatch.setenv("REDIS_PASSWORD", "")
+    monkeypatch.setenv("AUTH_COOKIE_SECURE", "false")
+    monkeypatch.setenv("WORKSPACE_INVITATION_TTL_SECONDS", "3600")
+
+    get_settings.cache_clear()
+    settings = get_settings()
+    engine = create_engine(f"sqlite+pysqlite:///{database_path}", future=True)
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    Base.metadata.create_all(engine)
+    _TEST_REDIS._values.clear()
+
+    app = create_app(settings)
+
+    def override_db_session() -> Generator[Session]:
+        session = session_factory()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_db_session] = override_db_session
+
+    with TestClient(app) as client:
+        yield client
+
+    app.dependency_overrides.clear()
+    Base.metadata.drop_all(engine)
+
+
+def test_unauthenticated_account_access_is_rejected(accounts_client: TestClient) -> None:
+    response = accounts_client.get(
+        "/api/v1/workspaces/00000000-0000-0000-0000-000000000000/accounts"
+    )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Not authenticated."}
+
+
+def test_member_can_create_and_list_accounts(accounts_client: TestClient) -> None:
+    owner_client = _sign_up_and_sign_in(accounts_client, "owner@example.com")
+    member_client = _sign_up_and_sign_in(accounts_client, "member@example.com")
+    workspace = _create_workspace(owner_client, name="Casa", workspace_type="shared")
+    invitation = _create_invitation(
+        owner_client,
+        workspace_id=workspace["id"],
+        email="member@example.com",
+    )
+    accept_response = member_client.post(
+        "/api/v1/workspaces/invitations/accept",
+        json={"token": invitation["invitation_token"]},
+    )
+    assert accept_response.status_code == 200
+
+    create_response = member_client.post(
+        f"/api/v1/workspaces/{workspace['id']}/accounts",
+        json={
+            "name": "Cuenta Principal",
+            "type": "bank_account",
+            "currency": "ars",
+            "initial_balance_minor": 125000,
+            "description": "Cuenta sueldo",
+        },
+    )
+    list_response = member_client.get(f"/api/v1/workspaces/{workspace['id']}/accounts")
+
+    assert create_response.status_code == 201
+    created_account = create_response.json()
+    assert created_account["name"] == "Cuenta Principal"
+    assert created_account["type"] == "bank_account"
+    assert created_account["currency"] == "ARS"
+    assert created_account["initial_balance_minor"] == 125000
+    assert created_account["current_balance_minor"] == 125000
+    assert created_account["description"] == "Cuenta sueldo"
+    assert created_account["archived_at"] is None
+    assert created_account["is_archived"] is False
+
+    assert list_response.status_code == 200
+    assert [account["id"] for account in list_response.json()["accounts"]] == [
+        created_account["id"]
+    ]
+
+
+def test_account_update_changes_initial_and_current_balance(accounts_client: TestClient) -> None:
+    owner_client = _sign_up_and_sign_in(accounts_client, "owner@example.com")
+    workspace = _create_workspace(owner_client, name="Finanzas", workspace_type="personal")
+    account = _create_account(
+        owner_client,
+        workspace_id=workspace["id"],
+        name="Efectivo",
+        account_type="cash",
+        currency="usd",
+        initial_balance_minor=1000,
+        description="Caja chica",
+    )
+
+    response = owner_client.patch(
+        f"/api/v1/workspaces/{workspace['id']}/accounts/{account['id']}",
+        json={
+            "name": "Efectivo diario",
+            "type": "savings_account",
+            "initial_balance_minor": 1500,
+            "description": "Uso cotidiano",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["name"] == "Efectivo diario"
+    assert payload["type"] == "savings_account"
+    assert payload["currency"] == "USD"
+    assert payload["initial_balance_minor"] == 1500
+    assert payload["current_balance_minor"] == 1500
+    assert payload["description"] == "Uso cotidiano"
+
+
+def test_archived_account_is_hidden_by_default_and_name_can_be_reused(
+    accounts_client: TestClient,
+) -> None:
+    owner_client = _sign_up_and_sign_in(accounts_client, "owner@example.com")
+    workspace = _create_workspace(owner_client, name="Ahorros", workspace_type="personal")
+    account = _create_account(
+        owner_client,
+        workspace_id=workspace["id"],
+        name="Banco Nación",
+        account_type="bank_account",
+        currency="ARS",
+        initial_balance_minor=100,
+        description=None,
+    )
+
+    archive_response = owner_client.post(
+        f"/api/v1/workspaces/{workspace['id']}/accounts/{account['id']}/archive"
+    )
+    active_list_response = owner_client.get(f"/api/v1/workspaces/{workspace['id']}/accounts")
+    all_list_response = owner_client.get(
+        f"/api/v1/workspaces/{workspace['id']}/accounts?include_archived=true"
+    )
+    reused_response = owner_client.post(
+        f"/api/v1/workspaces/{workspace['id']}/accounts",
+        json={
+            "name": "Banco Nación",
+            "type": "savings_account",
+            "currency": "ARS",
+            "initial_balance_minor": 200,
+            "description": None,
+        },
+    )
+
+    assert archive_response.status_code == 200
+    assert archive_response.json()["is_archived"] is True
+    assert archive_response.json()["archived_at"] is not None
+    assert active_list_response.status_code == 200
+    assert active_list_response.json()["accounts"] == []
+    assert all_list_response.status_code == 200
+    assert len(all_list_response.json()["accounts"]) == 1
+    assert reused_response.status_code == 201
+    assert reused_response.json()["name"] == "Banco Nación"
+
+
+def test_duplicate_active_account_name_is_rejected(accounts_client: TestClient) -> None:
+    owner_client = _sign_up_and_sign_in(accounts_client, "owner@example.com")
+    workspace = _create_workspace(owner_client, name="Duplicados", workspace_type="personal")
+    first_response = owner_client.post(
+        f"/api/v1/workspaces/{workspace['id']}/accounts",
+        json={
+            "name": "Tarjeta Visa",
+            "type": "credit_card",
+            "currency": "ARS",
+            "initial_balance_minor": 0,
+            "description": None,
+        },
+    )
+    duplicate_response = owner_client.post(
+        f"/api/v1/workspaces/{workspace['id']}/accounts",
+        json={
+            "name": " tarjeta visa ",
+            "type": "credit_card",
+            "currency": "ARS",
+            "initial_balance_minor": 0,
+            "description": None,
+        },
+    )
+
+    assert first_response.status_code == 201
+    assert duplicate_response.status_code == 409
+    assert duplicate_response.json() == {
+        "detail": "An active account with that name already exists in this workspace."
+    }
+
+
+def test_workspace_isolation_and_non_member_access_are_enforced(
+    accounts_client: TestClient,
+) -> None:
+    owner_client = _sign_up_and_sign_in(accounts_client, "owner@example.com")
+    outsider_client = _sign_up_and_sign_in(accounts_client, "outsider@example.com")
+    workspace = _create_workspace(owner_client, name="Privado", workspace_type="shared")
+    account = _create_account(
+        owner_client,
+        workspace_id=workspace["id"],
+        name="Cuenta Reservada",
+        account_type="bank_account",
+        currency="EUR",
+        initial_balance_minor=500,
+        description=None,
+    )
+    outsider_workspace = _create_workspace(
+        outsider_client,
+        name="Ajeno",
+        workspace_type="personal",
+    )
+
+    list_response = outsider_client.get(f"/api/v1/workspaces/{workspace['id']}/accounts")
+    update_response = outsider_client.patch(
+        f"/api/v1/workspaces/{workspace['id']}/accounts/{account['id']}",
+        json={"name": "Intrusion"},
+    )
+    cross_workspace_response = owner_client.patch(
+        f"/api/v1/workspaces/{outsider_workspace['id']}/accounts/{account['id']}",
+        json={"name": "Wrong workspace"},
+    )
+
+    assert list_response.status_code == 403
+    assert list_response.json() == {"detail": "You do not have access to this workspace."}
+    assert update_response.status_code == 403
+    assert update_response.json() == {"detail": "You do not have access to this workspace."}
+    assert cross_workspace_response.status_code == 403
+    assert cross_workspace_response.json() == {
+        "detail": "You do not have access to this workspace."
+    }
+
+
+def test_account_not_found_is_scoped_to_workspace(accounts_client: TestClient) -> None:
+    owner_client = _sign_up_and_sign_in(accounts_client, "owner@example.com")
+    another_client = _sign_up_and_sign_in(accounts_client, "another@example.com")
+    workspace = _create_workspace(owner_client, name="Casa", workspace_type="personal")
+    other_workspace = _create_workspace(another_client, name="Otro", workspace_type="personal")
+    account = _create_account(
+        another_client,
+        workspace_id=other_workspace["id"],
+        name="Cuenta Externa",
+        account_type="bank_account",
+        currency="USD",
+        initial_balance_minor=400,
+        description=None,
+    )
+
+    response = owner_client.patch(
+        f"/api/v1/workspaces/{workspace['id']}/accounts/{account['id']}",
+        json={"name": "No existe"},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Account not found."}
+
+
+def test_archived_account_cannot_be_updated(accounts_client: TestClient) -> None:
+    owner_client = _sign_up_and_sign_in(accounts_client, "owner@example.com")
+    workspace = _create_workspace(owner_client, name="Historial", workspace_type="personal")
+    account = _create_account(
+        owner_client,
+        workspace_id=workspace["id"],
+        name="Caja",
+        account_type="cash",
+        currency="ARS",
+        initial_balance_minor=300,
+        description=None,
+    )
+    archive_response = owner_client.post(
+        f"/api/v1/workspaces/{workspace['id']}/accounts/{account['id']}/archive"
+    )
+    assert archive_response.status_code == 200
+
+    update_response = owner_client.patch(
+        f"/api/v1/workspaces/{workspace['id']}/accounts/{account['id']}",
+        json={"name": "Caja nueva"},
+    )
+
+    assert update_response.status_code == 409
+    assert update_response.json() == {"detail": "Archived accounts cannot be updated."}
+
+
+def _sign_up_and_sign_in(client: TestClient, email: str) -> TestClient:
+    session_client = TestClient(cast(FastAPI, client.app))
+    response = session_client.post(
+        "/api/v1/auth/sign-up",
+        json={"email": email, "password": "secret123"},
+    )
+    assert response.status_code == 201
+    response = session_client.post(
+        "/api/v1/auth/sign-in",
+        json={"email": email, "password": "secret123"},
+    )
+    assert response.status_code == 200
+    return session_client
+
+
+def _create_workspace(client: TestClient, *, name: str, workspace_type: str) -> dict[str, str]:
+    response = client.post(
+        "/api/v1/workspaces",
+        json={"name": name, "type": workspace_type},
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+def _create_invitation(client: TestClient, *, workspace_id: str, email: str) -> dict[str, str]:
+    response = client.post(
+        f"/api/v1/workspaces/{workspace_id}/invitations",
+        json={"email": email},
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+def _create_account(
+    client: TestClient,
+    *,
+    workspace_id: str,
+    name: str,
+    account_type: str,
+    currency: str,
+    initial_balance_minor: int,
+    description: str | None,
+) -> dict[str, object]:
+    response = client.post(
+        f"/api/v1/workspaces/{workspace_id}/accounts",
+        json={
+            "name": name,
+            "type": account_type,
+            "currency": currency,
+            "initial_balance_minor": initial_balance_minor,
+            "description": description,
+        },
+    )
+    assert response.status_code == 201
+    return response.json()

--- a/backend/tests/test_categories.py
+++ b/backend/tests/test_categories.py
@@ -1,0 +1,407 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from pathlib import Path
+from typing import cast
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.api.dependencies.auth import _TEST_REDIS
+from app.core.config import get_settings
+from app.db.base import Base
+from app.db.models import User, Workspace, WorkspaceMember, WorkspaceMemberRole, WorkspaceType
+from app.db.session import get_db_session
+from app.main import create_app
+from app.repositories.categories import CategoryRepository
+
+
+@pytest.fixture
+def categories_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient]:
+    database_path = tmp_path / "categories.db"
+    monkeypatch.setenv("APP_ENV", "test")
+    monkeypatch.setenv("APP_DEBUG", "false")
+    monkeypatch.setenv("API_V1_PREFIX", "/api/v1")
+    monkeypatch.setenv("DATABASE_HOST", "localhost")
+    monkeypatch.setenv("DATABASE_PORT", "5432")
+    monkeypatch.setenv("DATABASE_NAME", "shared_expenses_test")
+    monkeypatch.setenv("DATABASE_USER", "postgres")
+    monkeypatch.setenv("DATABASE_PASSWORD", "postgres")
+    monkeypatch.setenv("DATABASE_ECHO", "false")
+    monkeypatch.setenv("REDIS_HOST", "localhost")
+    monkeypatch.setenv("REDIS_PORT", "6379")
+    monkeypatch.setenv("REDIS_DB", "0")
+    monkeypatch.setenv("REDIS_PASSWORD", "")
+    monkeypatch.setenv("AUTH_COOKIE_SECURE", "false")
+    monkeypatch.setenv("WORKSPACE_INVITATION_TTL_SECONDS", "3600")
+
+    get_settings.cache_clear()
+    settings = get_settings()
+    engine = create_engine(f"sqlite+pysqlite:///{database_path}", future=True)
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    Base.metadata.create_all(engine)
+    _TEST_REDIS._values.clear()
+
+    app = create_app(settings)
+
+    def override_db_session() -> Generator[Session]:
+        session = session_factory()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_db_session] = override_db_session
+
+    with TestClient(app) as client:
+        yield client
+
+    app.dependency_overrides.clear()
+    Base.metadata.drop_all(engine)
+
+
+def test_unauthenticated_category_access_is_rejected(categories_client: TestClient) -> None:
+    response = categories_client.get(
+        "/api/v1/workspaces/00000000-0000-0000-0000-000000000000/categories"
+    )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Not authenticated."}
+
+
+def test_workspace_creation_seeds_default_categories(categories_client: TestClient) -> None:
+    owner_client = _sign_up_and_sign_in(categories_client, "owner@example.com")
+    workspace = _create_workspace(owner_client, name="Casa", workspace_type="personal")
+
+    response = owner_client.get(f"/api/v1/workspaces/{workspace['id']}/categories")
+
+    assert response.status_code == 200
+    categories = response.json()["categories"]
+    assert len(categories) == 12
+    assert {category["type"] for category in categories} == {"income", "expense"}
+    assert any(category["name"] == "Comida" for category in categories)
+    assert any(category["name"] == "Gastos financieros" for category in categories)
+    assert all(category["archived_at"] is None for category in categories)
+
+
+def test_member_can_create_update_and_archive_categories(categories_client: TestClient) -> None:
+    owner_client = _sign_up_and_sign_in(categories_client, "owner@example.com")
+    member_client = _sign_up_and_sign_in(categories_client, "member@example.com")
+    workspace = _create_workspace(owner_client, name="Casa", workspace_type="shared")
+    invitation = _create_invitation(
+        owner_client,
+        workspace_id=workspace["id"],
+        email="member@example.com",
+    )
+    accept_response = member_client.post(
+        "/api/v1/workspaces/invitations/accept",
+        json={"token": invitation["invitation_token"]},
+    )
+    assert accept_response.status_code == 200
+
+    create_response = member_client.post(
+        f"/api/v1/workspaces/{workspace['id']}/categories",
+        json={
+            "name": "Mascotas",
+            "type": "expense",
+            "icon": "paw-print",
+            "color": "#84CC16",
+        },
+    )
+    created_category = create_response.json()
+
+    update_response = member_client.patch(
+        f"/api/v1/workspaces/{workspace['id']}/categories/{created_category['id']}",
+        json={
+            "name": "Veterinaria",
+            "icon": "stethoscope",
+            "color": "#16A34A",
+        },
+    )
+    archive_response = member_client.post(
+        f"/api/v1/workspaces/{workspace['id']}/categories/{created_category['id']}/archive"
+    )
+    active_response = member_client.get(f"/api/v1/workspaces/{workspace['id']}/categories")
+    all_response = member_client.get(
+        f"/api/v1/workspaces/{workspace['id']}/categories?include_archived=true"
+    )
+
+    assert create_response.status_code == 201
+    assert created_category["name"] == "Mascotas"
+    assert created_category["type"] == "expense"
+    assert created_category["icon"] == "paw-print"
+    assert created_category["color"] == "#84CC16"
+
+    assert update_response.status_code == 200
+    assert update_response.json()["name"] == "Veterinaria"
+    assert update_response.json()["icon"] == "stethoscope"
+    assert update_response.json()["color"] == "#16A34A"
+
+    assert archive_response.status_code == 200
+    assert archive_response.json()["is_archived"] is True
+    assert archive_response.json()["archived_at"] is not None
+    assert active_response.status_code == 200
+    active_names = {category["name"] for category in active_response.json()["categories"]}
+    assert "Veterinaria" not in active_names
+    assert all_response.status_code == 200
+    assert any(category["name"] == "Veterinaria" for category in all_response.json()["categories"])
+
+
+def test_duplicate_active_category_name_is_scoped_by_type(categories_client: TestClient) -> None:
+    owner_client = _sign_up_and_sign_in(categories_client, "owner@example.com")
+    workspace = _create_workspace(owner_client, name="Duplicados", workspace_type="personal")
+
+    first_response = owner_client.post(
+        f"/api/v1/workspaces/{workspace['id']}/categories",
+        json={
+            "name": "Bonus",
+            "type": "income",
+            "icon": "badge-dollar-sign",
+            "color": "#15803D",
+        },
+    )
+    duplicate_response = owner_client.post(
+        f"/api/v1/workspaces/{workspace['id']}/categories",
+        json={
+            "name": " bonus ",
+            "type": "income",
+            "icon": "wallet",
+            "color": "#16A34A",
+        },
+    )
+    different_type_response = owner_client.post(
+        f"/api/v1/workspaces/{workspace['id']}/categories",
+        json={
+            "name": "Bonus",
+            "type": "expense",
+            "icon": "receipt",
+            "color": "#DC2626",
+        },
+    )
+
+    assert first_response.status_code == 201
+    assert duplicate_response.status_code == 409
+    assert duplicate_response.json() == {
+        "detail": "An active category with that type and name already exists in this workspace."
+    }
+    assert different_type_response.status_code == 201
+
+
+def test_archived_category_name_can_be_reused(categories_client: TestClient) -> None:
+    owner_client = _sign_up_and_sign_in(categories_client, "owner@example.com")
+    workspace = _create_workspace(owner_client, name="Archivo", workspace_type="personal")
+    category = _create_category(
+        owner_client,
+        workspace_id=workspace["id"],
+        name="Temporal",
+        category_type="expense",
+        icon="archive",
+        color="#6B7280",
+    )
+
+    archive_response = owner_client.post(
+        f"/api/v1/workspaces/{workspace['id']}/categories/{category['id']}/archive"
+    )
+    reused_response = owner_client.post(
+        f"/api/v1/workspaces/{workspace['id']}/categories",
+        json={
+            "name": "Temporal",
+            "type": "expense",
+            "icon": "archive-restore",
+            "color": "#4B5563",
+        },
+    )
+
+    assert archive_response.status_code == 200
+    assert reused_response.status_code == 201
+    assert reused_response.json()["name"] == "Temporal"
+
+
+def test_workspace_isolation_and_non_member_access_are_enforced(
+    categories_client: TestClient,
+) -> None:
+    owner_client = _sign_up_and_sign_in(categories_client, "owner@example.com")
+    outsider_client = _sign_up_and_sign_in(categories_client, "outsider@example.com")
+    workspace = _create_workspace(owner_client, name="Privado", workspace_type="shared")
+    category = _create_category(
+        owner_client,
+        workspace_id=workspace["id"],
+        name="Reservado",
+        category_type="expense",
+        icon="lock",
+        color="#111827",
+    )
+    outsider_workspace = _create_workspace(
+        outsider_client,
+        name="Ajeno",
+        workspace_type="personal",
+    )
+
+    list_response = outsider_client.get(f"/api/v1/workspaces/{workspace['id']}/categories")
+    update_response = outsider_client.patch(
+        f"/api/v1/workspaces/{workspace['id']}/categories/{category['id']}",
+        json={"name": "Intrusion"},
+    )
+    cross_workspace_response = owner_client.patch(
+        f"/api/v1/workspaces/{outsider_workspace['id']}/categories/{category['id']}",
+        json={"name": "Wrong workspace"},
+    )
+
+    assert list_response.status_code == 403
+    assert list_response.json() == {"detail": "You do not have access to this workspace."}
+    assert update_response.status_code == 403
+    assert update_response.json() == {"detail": "You do not have access to this workspace."}
+    assert cross_workspace_response.status_code == 403
+    assert cross_workspace_response.json() == {
+        "detail": "You do not have access to this workspace."
+    }
+
+
+def test_category_not_found_is_scoped_to_workspace(categories_client: TestClient) -> None:
+    owner_client = _sign_up_and_sign_in(categories_client, "owner@example.com")
+    another_client = _sign_up_and_sign_in(categories_client, "another@example.com")
+    workspace = _create_workspace(owner_client, name="Casa", workspace_type="personal")
+    other_workspace = _create_workspace(another_client, name="Otro", workspace_type="personal")
+    category = _create_category(
+        another_client,
+        workspace_id=other_workspace["id"],
+        name="Externa",
+        category_type="expense",
+        icon="globe",
+        color="#2563EB",
+    )
+
+    response = owner_client.patch(
+        f"/api/v1/workspaces/{workspace['id']}/categories/{category['id']}",
+        json={"name": "No existe"},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Category not found."}
+
+
+def test_archived_category_cannot_be_updated(categories_client: TestClient) -> None:
+    owner_client = _sign_up_and_sign_in(categories_client, "owner@example.com")
+    workspace = _create_workspace(owner_client, name="Historial", workspace_type="personal")
+    category = _create_category(
+        owner_client,
+        workspace_id=workspace["id"],
+        name="Caja vieja",
+        category_type="expense",
+        icon="box",
+        color="#92400E",
+    )
+    archive_response = owner_client.post(
+        f"/api/v1/workspaces/{workspace['id']}/categories/{category['id']}/archive"
+    )
+    assert archive_response.status_code == 200
+
+    update_response = owner_client.patch(
+        f"/api/v1/workspaces/{workspace['id']}/categories/{category['id']}",
+        json={"name": "Caja nueva"},
+    )
+
+    assert update_response.status_code == 409
+    assert update_response.json() == {"detail": "Archived categories cannot be updated."}
+
+
+def test_default_category_backfill_is_idempotent(categories_client: TestClient) -> None:
+    owner_client = _sign_up_and_sign_in(categories_client, "owner@example.com")
+    app = cast(FastAPI, categories_client.app)
+    session_factory = app.dependency_overrides[get_db_session]
+    session_generator = session_factory()
+    session = next(session_generator)
+    try:
+        owner = session.scalar(select(User).where(User.email == "owner@example.com"))
+        assert owner is not None
+
+        workspace = Workspace(
+            name="Legacy",
+            type=WorkspaceType.PERSONAL,
+            created_by_user_id=owner.id,
+        )
+        session.add(workspace)
+        session.flush()
+        session.add(
+            WorkspaceMember(
+                workspace_id=workspace.id,
+                user_id=owner.id,
+                role=WorkspaceMemberRole.OWNER,
+            )
+        )
+        session.commit()
+        workspace_id = str(workspace.id)
+
+        repository = CategoryRepository(session)
+        first_batch = repository.ensure_default_categories_for_workspace(workspace_id=workspace.id)
+        second_batch = repository.ensure_default_categories_for_workspace(workspace_id=workspace.id)
+        session.commit()
+
+        assert len(first_batch) == 12
+        assert second_batch == []
+    finally:
+        session.close()
+        session_generator.close()
+
+    response = owner_client.get(f"/api/v1/workspaces/{workspace_id}/categories")
+
+    assert response.status_code == 200
+    assert len(response.json()["categories"]) == 12
+
+
+def _sign_up_and_sign_in(client: TestClient, email: str) -> TestClient:
+    session_client = TestClient(cast(FastAPI, client.app))
+    response = session_client.post(
+        "/api/v1/auth/sign-up",
+        json={"email": email, "password": "secret123"},
+    )
+    assert response.status_code == 201
+    response = session_client.post(
+        "/api/v1/auth/sign-in",
+        json={"email": email, "password": "secret123"},
+    )
+    assert response.status_code == 200
+    return session_client
+
+
+def _create_workspace(client: TestClient, *, name: str, workspace_type: str) -> dict[str, str]:
+    response = client.post(
+        "/api/v1/workspaces",
+        json={"name": name, "type": workspace_type},
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+def _create_invitation(client: TestClient, *, workspace_id: str, email: str) -> dict[str, str]:
+    response = client.post(
+        f"/api/v1/workspaces/{workspace_id}/invitations",
+        json={"email": email},
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+def _create_category(
+    client: TestClient,
+    *,
+    workspace_id: str,
+    name: str,
+    category_type: str,
+    icon: str,
+    color: str,
+) -> dict[str, object]:
+    response = client.post(
+        f"/api/v1/workspaces/{workspace_id}/categories",
+        json={
+            "name": name,
+            "type": category_type,
+            "icon": icon,
+            "color": color,
+        },
+    )
+    assert response.status_code == 201
+    return response.json()

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -229,3 +229,9 @@ Likely future schema extensions include:
 - settlement-specific records or derived net balance views
 
 Those additions should be layered onto the core model rather than forcing a redesign of workspace, accounts, categories, and transactions.
+
+## Implemented category notes
+
+- categories are workspace-scoped records with `name`, `type`, `icon`, `color`, and nullable `archived_at`
+- active uniqueness is enforced on `(workspace_id, type, lower(name))`, allowing archived names to be reused later
+- workspace creation and migration backfill both use the same default-category seed set so existing and new workspaces converge on the same baseline

--- a/docs/architecture/runtime-flows.md
+++ b/docs/architecture/runtime-flows.md
@@ -118,6 +118,7 @@ sequenceDiagram
     Frontend->>Backend: POST /workspaces
     Backend->>DB: Create workspace
     Backend->>DB: Create owner membership
+    Backend->>DB: Seed default workspace categories if missing
     Backend-->>Frontend: Return workspace data
     Frontend-->>User: Show workspace home
 ```
@@ -126,6 +127,7 @@ Notes:
 
 - the creator always becomes the `owner` member of the workspace
 - both personal and shared workspaces use the same membership model
+- workspace onboarding also seeds the default income and expense categories used by future selectors
 
 ## 7. Workspace invitation acceptance flow
 

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -46,7 +46,9 @@ main {
 }
 
 button,
-input {
+input,
+select,
+textarea {
   font: inherit;
 }
 
@@ -171,6 +173,11 @@ input {
   background: rgba(255, 255, 255, 0.72);
   color: var(--foreground);
   transition: border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
+}
+
+.auth-textarea {
+  resize: vertical;
+  min-height: 7rem;
 }
 
 .auth-input:focus {
@@ -478,6 +485,79 @@ input {
   font-weight: 700;
 }
 
+.entity-section,
+.entity-list,
+.entity-inline-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.entity-section {
+  margin-top: 1.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid rgba(86, 62, 34, 0.12);
+}
+
+.entity-card {
+  display: grid;
+  gap: 1rem;
+  padding: 1.1rem;
+  border: 1px solid rgba(86, 62, 34, 0.12);
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.44);
+}
+
+.entity-card-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.entity-card-side {
+  display: grid;
+  gap: 0.35rem;
+  justify-items: end;
+}
+
+.entity-split-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.entity-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.entity-submit,
+.entity-secondary-action,
+.entity-danger-action {
+  min-width: 0;
+}
+
+.entity-danger-action {
+  border-color: rgba(171, 60, 47, 0.18);
+  color: #8d2c22;
+  background: rgba(171, 60, 47, 0.08);
+}
+
+.account-balance {
+  font-size: 1.35rem;
+  font-weight: 700;
+}
+
+.entity-color-swatch {
+  width: 2.25rem;
+  height: 2.25rem;
+  border: 2px solid rgba(86, 62, 34, 0.16);
+  border-radius: 999px;
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.12);
+}
+
 .dashboard-stats {
   display: grid;
   gap: 1rem;
@@ -651,6 +731,10 @@ input {
   }
 
   .workspace-facts {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .entity-split-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }

--- a/frontend/src/components/accounts/account-form.tsx
+++ b/frontend/src/components/accounts/account-form.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import React from "react";
+import { useEffect, useTransition } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+import {
+  ACCOUNT_TYPE_OPTIONS,
+  buildAccountPayload,
+} from "@/lib/accounts/presentation";
+import { accountFormSchema, type AccountFormValues } from "@/lib/accounts/schemas";
+import type { AccountCreatePayload } from "@/lib/accounts/types";
+
+export const DEFAULT_ACCOUNT_FORM_VALUES: AccountFormValues = {
+  name: "",
+  type: "bank_account",
+  currency: "EUR",
+  initialBalance: "0.00",
+  description: "",
+};
+
+type AccountFormProps = {
+  defaultValues?: AccountFormValues;
+  submitLabel: string;
+  submittingLabel: string;
+  onSubmitAccount: (payload: AccountCreatePayload) => Promise<boolean>;
+  onCancel?: () => void;
+  resetOnSuccess?: boolean;
+  fieldIdPrefix: string;
+};
+
+export function AccountForm({
+  defaultValues = DEFAULT_ACCOUNT_FORM_VALUES,
+  submitLabel,
+  submittingLabel,
+  onSubmitAccount,
+  onCancel,
+  resetOnSuccess = false,
+  fieldIdPrefix,
+}: AccountFormProps) {
+  const [isPending, startTransition] = useTransition();
+  const form = useForm<AccountFormValues>({
+    resolver: zodResolver(accountFormSchema),
+    defaultValues,
+  });
+
+  useEffect(() => {
+    form.reset(defaultValues);
+  }, [defaultValues, form]);
+
+  const onSubmit = form.handleSubmit((values) => {
+    startTransition(async () => {
+      const isSuccessful = await onSubmitAccount(buildAccountPayload(values));
+
+      if (!isSuccessful) {
+        return;
+      }
+
+      if (resetOnSuccess) {
+        form.reset(DEFAULT_ACCOUNT_FORM_VALUES);
+      }
+
+      onCancel?.();
+    });
+  });
+
+  return (
+    <form className="workspace-form" onSubmit={onSubmit} noValidate>
+      <div className="entity-split-grid">
+        <label className="auth-field" htmlFor={`${fieldIdPrefix}-name`}>
+          <span className="auth-label">Nombre</span>
+          <input
+            id={`${fieldIdPrefix}-name`}
+            className="auth-input"
+            type="text"
+            placeholder="Ej. Cuenta principal"
+            aria-invalid={Boolean(form.formState.errors.name)}
+            {...form.register("name")}
+          />
+          {form.formState.errors.name ? (
+            <span className="auth-field-error">{form.formState.errors.name.message}</span>
+          ) : null}
+        </label>
+
+        <label className="auth-field" htmlFor={`${fieldIdPrefix}-type`}>
+          <span className="auth-label">Tipo</span>
+          <select
+            id={`${fieldIdPrefix}-type`}
+            className="auth-input"
+            aria-invalid={Boolean(form.formState.errors.type)}
+            {...form.register("type")}
+          >
+            {ACCOUNT_TYPE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          {form.formState.errors.type ? (
+            <span className="auth-field-error">{form.formState.errors.type.message}</span>
+          ) : null}
+        </label>
+
+        <label className="auth-field" htmlFor={`${fieldIdPrefix}-currency`}>
+          <span className="auth-label">Moneda</span>
+          <input
+            id={`${fieldIdPrefix}-currency`}
+            className="auth-input"
+            type="text"
+            inputMode="text"
+            maxLength={3}
+            placeholder="EUR"
+            aria-invalid={Boolean(form.formState.errors.currency)}
+            {...form.register("currency")}
+          />
+          {form.formState.errors.currency ? (
+            <span className="auth-field-error">{form.formState.errors.currency.message}</span>
+          ) : null}
+        </label>
+
+        <label className="auth-field" htmlFor={`${fieldIdPrefix}-initial-balance`}>
+          <span className="auth-label">Saldo inicial</span>
+          <input
+            id={`${fieldIdPrefix}-initial-balance`}
+            className="auth-input"
+            type="text"
+            inputMode="decimal"
+            placeholder="0.00"
+            aria-invalid={Boolean(form.formState.errors.initialBalance)}
+            {...form.register("initialBalance")}
+          />
+          {form.formState.errors.initialBalance ? (
+            <span className="auth-field-error">{form.formState.errors.initialBalance.message}</span>
+          ) : null}
+        </label>
+      </div>
+
+      <label className="auth-field" htmlFor={`${fieldIdPrefix}-description`}>
+        <span className="auth-label">Descripcion</span>
+        <textarea
+          id={`${fieldIdPrefix}-description`}
+          className="auth-input auth-textarea"
+          rows={3}
+          placeholder="Opcional. Anota detalles para identificar la cuenta."
+          aria-invalid={Boolean(form.formState.errors.description)}
+          {...form.register("description")}
+        />
+        {form.formState.errors.description ? (
+          <span className="auth-field-error">{form.formState.errors.description.message}</span>
+        ) : null}
+      </label>
+
+      <div className="entity-actions">
+        <button className="primary-action entity-submit" type="submit" disabled={isPending}>
+          {isPending ? submittingLabel : submitLabel}
+        </button>
+        {onCancel ? (
+          <button className="secondary-action entity-secondary-action" onClick={onCancel} type="button">
+            Cancelar
+          </button>
+        ) : null}
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/components/accounts/accounts-panel.test.tsx
+++ b/frontend/src/components/accounts/accounts-panel.test.tsx
@@ -1,0 +1,185 @@
+import React from "react";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AccountsPanel } from "@/components/accounts/accounts-panel";
+
+const archiveAccountMock = vi.fn();
+const createAccountMock = vi.fn();
+const listAccountsMock = vi.fn();
+const updateAccountMock = vi.fn();
+
+vi.mock("@/lib/accounts/api", () => ({
+  archiveAccount: (...args: unknown[]) => archiveAccountMock(...args),
+  createAccount: (...args: unknown[]) => createAccountMock(...args),
+  listAccounts: (...args: unknown[]) => listAccountsMock(...args),
+  updateAccount: (...args: unknown[]) => updateAccountMock(...args),
+}));
+
+describe("AccountsPanel", () => {
+  const confirmSpy = vi.spyOn(window, "confirm");
+
+  beforeEach(() => {
+    archiveAccountMock.mockReset();
+    createAccountMock.mockReset();
+    listAccountsMock.mockReset();
+    updateAccountMock.mockReset();
+    confirmSpy.mockReset();
+  });
+
+  it("loads active accounts and shows current balances", async () => {
+    listAccountsMock.mockResolvedValue({
+      accounts: [
+        {
+          id: "acc-1",
+          workspace_id: "workspace-1",
+          name: "Cuenta principal",
+          type: "bank_account",
+          currency: "EUR",
+          initial_balance_minor: 120000,
+          current_balance_minor: 98550,
+          description: "Uso diario",
+          archived_at: null,
+          is_archived: false,
+          created_at: "2026-03-08T10:00:00Z",
+          updated_at: "2026-03-08T10:00:00Z",
+        },
+      ],
+    });
+
+    render(<AccountsPanel workspaceId="workspace-1" />);
+
+    expect(await screen.findByText("Cuenta principal")).toBeInTheDocument();
+    expect(screen.getAllByText("Cuenta bancaria")[0]).toBeInTheDocument();
+    expect(screen.getByText((content) => content.includes("985,50") && content.includes("€"))).toBeInTheDocument();
+    expect(listAccountsMock).toHaveBeenCalledWith("workspace-1");
+  });
+
+  it("creates, edits and archives accounts", async () => {
+    const user = userEvent.setup();
+
+    listAccountsMock.mockResolvedValue({
+      accounts: [
+        {
+          id: "acc-1",
+          workspace_id: "workspace-1",
+          name: "Cuenta principal",
+          type: "bank_account",
+          currency: "EUR",
+          initial_balance_minor: 120000,
+          current_balance_minor: 120000,
+          description: null,
+          archived_at: null,
+          is_archived: false,
+          created_at: "2026-03-08T10:00:00Z",
+          updated_at: "2026-03-08T10:00:00Z",
+        },
+      ],
+    });
+    createAccountMock.mockResolvedValue({
+      id: "acc-2",
+      workspace_id: "workspace-1",
+      name: "Tarjeta viaje",
+      type: "credit_card",
+      currency: "USD",
+      initial_balance_minor: -4550,
+      current_balance_minor: -4550,
+      description: "Reserva hotel",
+      archived_at: null,
+      is_archived: false,
+      created_at: "2026-03-08T10:00:00Z",
+      updated_at: "2026-03-08T10:00:00Z",
+    });
+    updateAccountMock.mockResolvedValue({
+      id: "acc-1",
+      workspace_id: "workspace-1",
+      name: "Cuenta hogar",
+      type: "savings_account",
+      currency: "EUR",
+      initial_balance_minor: 200000,
+      current_balance_minor: 200000,
+      description: "Ahorro comun",
+      archived_at: null,
+      is_archived: false,
+      created_at: "2026-03-08T10:00:00Z",
+      updated_at: "2026-03-08T11:00:00Z",
+    });
+    archiveAccountMock.mockResolvedValue({ id: "acc-1", name: "Cuenta hogar" });
+    confirmSpy.mockReturnValue(true);
+
+    render(<AccountsPanel workspaceId="workspace-1" />);
+
+    await screen.findByText("Cuenta principal");
+
+    await user.clear(screen.getByLabelText(/^Nombre$/i));
+    await user.type(screen.getByLabelText(/^Nombre$/i), "Tarjeta viaje");
+    await user.selectOptions(screen.getByLabelText(/^Tipo$/i), "credit_card");
+    await user.clear(screen.getByLabelText(/^Moneda$/i));
+    await user.type(screen.getByLabelText(/^Moneda$/i), "usd");
+    await user.clear(screen.getByLabelText(/^Saldo inicial$/i));
+    await user.type(screen.getByLabelText(/^Saldo inicial$/i), "-45.50");
+    await user.clear(screen.getByLabelText(/^Descripcion$/i));
+    await user.type(screen.getByLabelText(/^Descripcion$/i), "Reserva hotel");
+    await user.click(screen.getByRole("button", { name: /crear cuenta/i }));
+
+    await waitFor(() => {
+      expect(createAccountMock).toHaveBeenCalledWith("workspace-1", {
+        name: "Tarjeta viaje",
+        type: "credit_card",
+        currency: "USD",
+        initial_balance_minor: -4550,
+        description: "Reserva hotel",
+      });
+    });
+
+    expect(await screen.findByText("Tarjeta viaje")).toBeInTheDocument();
+
+    const originalAccountCard = screen.getByText("Cuenta principal").closest("article");
+
+    expect(originalAccountCard).not.toBeNull();
+
+    await user.click(within(originalAccountCard as HTMLElement).getByRole("button", { name: /editar/i }));
+
+    const editNameInput = screen.getByLabelText("Nombre", { selector: "input[id='account-edit-acc-1-name']" });
+    const editTypeSelect = screen.getByLabelText("Tipo", { selector: "select[id='account-edit-acc-1-type']" });
+    const editBalanceInput = screen.getByLabelText("Saldo inicial", {
+      selector: "input[id='account-edit-acc-1-initial-balance']",
+    });
+    const editDescriptionInput = screen.getByLabelText("Descripcion", {
+      selector: "textarea[id='account-edit-acc-1-description']",
+    });
+
+    await user.clear(editNameInput);
+    await user.type(editNameInput, "Cuenta hogar");
+    await user.selectOptions(editTypeSelect, "savings_account");
+    await user.clear(editBalanceInput);
+    await user.type(editBalanceInput, "2000.00");
+    await user.clear(editDescriptionInput);
+    await user.type(editDescriptionInput, "Ahorro comun");
+    await user.click(screen.getByRole("button", { name: /guardar cambios/i }));
+
+    await waitFor(() => {
+      expect(updateAccountMock).toHaveBeenCalledWith("workspace-1", "acc-1", {
+        name: "Cuenta hogar",
+        type: "savings_account",
+        currency: "EUR",
+        initial_balance_minor: 200000,
+        description: "Ahorro comun",
+      });
+    });
+
+    expect(await screen.findByText("Cuenta hogar")).toBeInTheDocument();
+
+    const updatedAccountCard = screen.getByText("Cuenta hogar").closest("article");
+
+    expect(updatedAccountCard).not.toBeNull();
+
+    await user.click(within(updatedAccountCard as HTMLElement).getByRole("button", { name: /archivar/i }));
+
+    await waitFor(() => {
+      expect(archiveAccountMock).toHaveBeenCalledWith("workspace-1", "acc-1");
+    });
+    expect(screen.queryByText("Cuenta hogar")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/accounts/accounts-panel.tsx
+++ b/frontend/src/components/accounts/accounts-panel.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import React from "react";
+import { useEffect, useState } from "react";
+
+import { AccountForm, DEFAULT_ACCOUNT_FORM_VALUES } from "@/components/accounts/account-form";
+import { getErrorMessage } from "@/lib/auth/errors";
+import { archiveAccount, createAccount, listAccounts, updateAccount } from "@/lib/accounts/api";
+import {
+  ACCOUNT_TYPE_LABELS,
+  formatMinorUnitsAsCurrency,
+  formatMinorUnitsForInput,
+} from "@/lib/accounts/presentation";
+import type { Account, AccountCreatePayload } from "@/lib/accounts/types";
+
+type AccountsPanelProps = {
+  workspaceId: string;
+};
+
+type Notice = {
+  type: "error" | "success";
+  message: string;
+};
+
+function toAccountFormDefaults(account: Account) {
+  return {
+    name: account.name,
+    type: account.type,
+    currency: account.currency,
+    initialBalance: formatMinorUnitsForInput(account.initial_balance_minor),
+    description: account.description ?? "",
+  } as const;
+}
+
+export function AccountsPanel({ workspaceId }: AccountsPanelProps) {
+  const [accounts, setAccounts] = useState<Account[]>([]);
+  const [editingAccountId, setEditingAccountId] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [notice, setNotice] = useState<Notice | null>(null);
+
+  const loadAccounts = React.useCallback(async () => {
+    setIsLoading(true);
+
+    try {
+      const response = await listAccounts(workspaceId);
+      setAccounts(response.accounts);
+    } catch (error) {
+      setNotice({ type: "error", message: getErrorMessage(error) });
+    } finally {
+      setIsLoading(false);
+    }
+  }, [workspaceId]);
+
+  useEffect(() => {
+    setEditingAccountId(null);
+    setNotice(null);
+
+    void loadAccounts();
+  }, [loadAccounts]);
+
+  const handleCreate = async (payload: AccountCreatePayload) => {
+    setNotice(null);
+
+    try {
+      const account = await createAccount(workspaceId, payload);
+      setAccounts((currentAccounts) => [account, ...currentAccounts]);
+      setNotice({ type: "success", message: `Cuenta ${account.name} creada correctamente.` });
+      return true;
+    } catch (error) {
+      setNotice({ type: "error", message: getErrorMessage(error) });
+      return false;
+    }
+  };
+
+  const handleUpdate = async (accountId: string, payload: AccountCreatePayload) => {
+    setNotice(null);
+
+    try {
+      const updatedAccount = await updateAccount(workspaceId, accountId, payload);
+      setAccounts((currentAccounts) =>
+        currentAccounts.map((account) => (account.id === updatedAccount.id ? updatedAccount : account)),
+      );
+      setNotice({ type: "success", message: `Cuenta ${updatedAccount.name} actualizada.` });
+      return true;
+    } catch (error) {
+      setNotice({ type: "error", message: getErrorMessage(error) });
+      return false;
+    }
+  };
+
+  const handleArchive = async (account: Account) => {
+    const shouldArchive = window.confirm(
+      `Vas a archivar la cuenta ${account.name}. Seguira visible en el historial, pero dejara de aparecer como activa.`,
+    );
+
+    if (!shouldArchive) {
+      return;
+    }
+
+    setNotice(null);
+
+    try {
+      const archivedAccount = await archiveAccount(workspaceId, account.id);
+      setAccounts((currentAccounts) =>
+        currentAccounts.filter((currentAccount) => currentAccount.id !== archivedAccount.id),
+      );
+      if (editingAccountId === archivedAccount.id) {
+        setEditingAccountId(null);
+      }
+      setNotice({ type: "success", message: `Cuenta ${archivedAccount.name} archivada.` });
+    } catch (error) {
+      setNotice({ type: "error", message: getErrorMessage(error) });
+    }
+  };
+
+  return (
+    <section className="workspace-panel">
+      <div className="workspace-form-header">
+        <h2 className="workspace-section-title">Cuentas</h2>
+        <p className="workspace-section-copy">
+          Gestiona las cuentas activas del espacio y revisa su saldo actual en una sola vista.
+        </p>
+      </div>
+
+      {notice ? (
+        <div
+          className={`auth-feedback ${notice.type === "error" ? "auth-feedback-error" : "auth-feedback-success"}`}
+          role={notice.type === "error" ? "alert" : "status"}
+        >
+          {notice.message}
+        </div>
+      ) : null}
+
+      <div className="entity-section">
+        <div className="workspace-form-header">
+          <h3 className="workspace-section-title">Nueva cuenta</h3>
+          <p className="workspace-section-copy">
+            Registra efectivo, bancos, ahorros o tarjetas con su saldo inicial en moneda ISO.
+          </p>
+        </div>
+        <AccountForm
+          defaultValues={DEFAULT_ACCOUNT_FORM_VALUES}
+          fieldIdPrefix={`account-create-${workspaceId}`}
+          onSubmitAccount={handleCreate}
+          resetOnSuccess
+          submitLabel="Crear cuenta"
+          submittingLabel="Guardando..."
+        />
+      </div>
+
+      <div className="entity-list" aria-label="Cuentas activas del espacio">
+        {isLoading ? <p className="workspace-section-copy">Cargando cuentas...</p> : null}
+
+        {!isLoading && accounts.length === 0 ? (
+          <p className="workspace-section-copy">
+            Todavia no hay cuentas activas. Crea la primera para empezar a registrar movimientos.
+          </p>
+        ) : null}
+
+        {!isLoading
+          ? accounts.map((account) => {
+              const isEditing = editingAccountId === account.id;
+
+              return (
+                <article key={account.id} className="entity-card">
+                  <div className="entity-card-header">
+                    <div>
+                      <div className="workspace-list-topline">
+                        <strong>{account.name}</strong>
+                        <span className="workspace-role-chip">{ACCOUNT_TYPE_LABELS[account.type]}</span>
+                      </div>
+                      <p className="workspace-section-copy">
+                        {account.currency} · Saldo inicial {formatMinorUnitsAsCurrency(account.initial_balance_minor, account.currency)}
+                      </p>
+                    </div>
+                    <div className="entity-card-side">
+                      <span className="account-balance">
+                        {formatMinorUnitsAsCurrency(account.current_balance_minor, account.currency)}
+                      </span>
+                      <span className="workspace-member-date">Saldo actual</span>
+                    </div>
+                  </div>
+
+                  {account.description ? <p className="workspace-section-copy">{account.description}</p> : null}
+
+                  <div className="entity-actions">
+                    <button
+                      className="secondary-action entity-secondary-action"
+                      onClick={() => setEditingAccountId(isEditing ? null : account.id)}
+                      type="button"
+                    >
+                      {isEditing ? "Cerrar edicion" : "Editar"}
+                    </button>
+                    <button
+                      className="secondary-action entity-danger-action"
+                      onClick={() => {
+                        void handleArchive(account);
+                      }}
+                      type="button"
+                    >
+                      Archivar
+                    </button>
+                  </div>
+
+                  {isEditing ? (
+                    <div className="entity-inline-form">
+                      <div className="workspace-form-header">
+                        <h3 className="workspace-section-title">Editar cuenta</h3>
+                        <p className="workspace-section-copy">
+                          Actualiza el nombre, el tipo o el saldo base sin salir del tablero.
+                        </p>
+                      </div>
+                      <AccountForm
+                        defaultValues={toAccountFormDefaults(account)}
+                        fieldIdPrefix={`account-edit-${account.id}`}
+                        onCancel={() => setEditingAccountId(null)}
+                        onSubmitAccount={(payload) => handleUpdate(account.id, payload)}
+                        submitLabel="Guardar cambios"
+                        submittingLabel="Guardando..."
+                      />
+                    </div>
+                  ) : null}
+                </article>
+              );
+            })
+          : null}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/categories/categories-panel.test.tsx
+++ b/frontend/src/components/categories/categories-panel.test.tsx
@@ -1,0 +1,177 @@
+import React from "react";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CategoriesPanel } from "@/components/categories/categories-panel";
+
+const archiveCategoryMock = vi.fn();
+const createCategoryMock = vi.fn();
+const listCategoriesMock = vi.fn();
+const updateCategoryMock = vi.fn();
+
+vi.mock("@/lib/categories/api", () => ({
+  archiveCategory: (...args: unknown[]) => archiveCategoryMock(...args),
+  createCategory: (...args: unknown[]) => createCategoryMock(...args),
+  listCategories: (...args: unknown[]) => listCategoriesMock(...args),
+  updateCategory: (...args: unknown[]) => updateCategoryMock(...args),
+}));
+
+describe("CategoriesPanel", () => {
+  const confirmSpy = vi.spyOn(window, "confirm");
+
+  beforeEach(() => {
+    archiveCategoryMock.mockReset();
+    createCategoryMock.mockReset();
+    listCategoriesMock.mockReset();
+    updateCategoryMock.mockReset();
+    confirmSpy.mockReset();
+  });
+
+  it("loads active categories only by default", async () => {
+    listCategoriesMock.mockResolvedValue({
+      categories: [
+        {
+          id: "cat-1",
+          workspace_id: "workspace-1",
+          name: "Comida",
+          type: "expense",
+          icon: "utensils-crossed",
+          color: "#D97706",
+          archived_at: null,
+          is_archived: false,
+          created_at: "2026-03-08T10:00:00Z",
+          updated_at: "2026-03-08T10:00:00Z",
+        },
+        {
+          id: "cat-2",
+          workspace_id: "workspace-1",
+          name: "Archivada",
+          type: "expense",
+          icon: "archive",
+          color: "#111111",
+          archived_at: "2026-03-08T10:00:00Z",
+          is_archived: true,
+          created_at: "2026-03-08T10:00:00Z",
+          updated_at: "2026-03-08T10:00:00Z",
+        },
+      ],
+    });
+
+    render(<CategoriesPanel workspaceId="workspace-1" />);
+
+    expect(await screen.findByText("Comida")).toBeInTheDocument();
+    expect(screen.queryByText("Archivada")).not.toBeInTheDocument();
+    expect(listCategoriesMock).toHaveBeenCalledWith("workspace-1");
+  });
+
+  it("creates, edits and archives categories", async () => {
+    const user = userEvent.setup();
+
+    listCategoriesMock.mockResolvedValue({
+      categories: [
+        {
+          id: "cat-1",
+          workspace_id: "workspace-1",
+          name: "Comida",
+          type: "expense",
+          icon: "utensils-crossed",
+          color: "#D97706",
+          archived_at: null,
+          is_archived: false,
+          created_at: "2026-03-08T10:00:00Z",
+          updated_at: "2026-03-08T10:00:00Z",
+        },
+      ],
+    });
+    createCategoryMock.mockResolvedValue({
+      id: "cat-2",
+      workspace_id: "workspace-1",
+      name: "Mascotas",
+      type: "expense",
+      icon: "paw-print",
+      color: "#7C3AED",
+      archived_at: null,
+      is_archived: false,
+      created_at: "2026-03-08T10:00:00Z",
+      updated_at: "2026-03-08T10:00:00Z",
+    });
+    updateCategoryMock.mockResolvedValue({
+      id: "cat-1",
+      workspace_id: "workspace-1",
+      name: "Supermercado",
+      type: "expense",
+      icon: "shopping-basket",
+      color: "#2563EB",
+      archived_at: null,
+      is_archived: false,
+      created_at: "2026-03-08T10:00:00Z",
+      updated_at: "2026-03-08T11:00:00Z",
+    });
+    archiveCategoryMock.mockResolvedValue({ id: "cat-1", name: "Supermercado" });
+    confirmSpy.mockReturnValue(true);
+
+    render(<CategoriesPanel workspaceId="workspace-1" />);
+
+    await screen.findByText("Comida");
+
+    await user.clear(screen.getByLabelText(/^Nombre$/i));
+    await user.type(screen.getByLabelText(/^Nombre$/i), "Mascotas");
+    await user.clear(screen.getByLabelText(/^Icono$/i));
+    await user.type(screen.getByLabelText(/^Icono$/i), "paw-print");
+    await user.clear(screen.getByLabelText(/^Color$/i));
+    await user.type(screen.getByLabelText(/^Color$/i), "#7c3aed");
+    await user.click(screen.getByRole("button", { name: /crear categoria/i }));
+
+    await waitFor(() => {
+      expect(createCategoryMock).toHaveBeenCalledWith("workspace-1", {
+        name: "Mascotas",
+        type: "expense",
+        icon: "paw-print",
+        color: "#7C3AED",
+      });
+    });
+
+    expect(await screen.findByText("Mascotas")).toBeInTheDocument();
+
+    const originalCategoryCard = screen.getByText("Comida").closest("article");
+
+    expect(originalCategoryCard).not.toBeNull();
+
+    await user.click(within(originalCategoryCard as HTMLElement).getByRole("button", { name: /editar/i }));
+
+    const editNameInput = screen.getByLabelText("Nombre", { selector: "input[id='category-edit-cat-1-name']" });
+    const editIconInput = screen.getByLabelText("Icono", { selector: "input[id='category-edit-cat-1-icon']" });
+    const editColorInput = screen.getByLabelText("Color", { selector: "input[id='category-edit-cat-1-color']" });
+
+    await user.clear(editNameInput);
+    await user.type(editNameInput, "Supermercado");
+    await user.clear(editIconInput);
+    await user.type(editIconInput, "shopping-basket");
+    await user.clear(editColorInput);
+    await user.type(editColorInput, "#2563eb");
+    await user.click(screen.getByRole("button", { name: /guardar cambios/i }));
+
+    await waitFor(() => {
+      expect(updateCategoryMock).toHaveBeenCalledWith("workspace-1", "cat-1", {
+        name: "Supermercado",
+        type: "expense",
+        icon: "shopping-basket",
+        color: "#2563EB",
+      });
+    });
+
+    expect(await screen.findByText("Supermercado")).toBeInTheDocument();
+
+    const updatedCategoryCard = screen.getByText("Supermercado").closest("article");
+
+    expect(updatedCategoryCard).not.toBeNull();
+
+    await user.click(within(updatedCategoryCard as HTMLElement).getByRole("button", { name: /archivar/i }));
+
+    await waitFor(() => {
+      expect(archiveCategoryMock).toHaveBeenCalledWith("workspace-1", "cat-1");
+    });
+    expect(screen.queryByText("Supermercado")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/categories/categories-panel.tsx
+++ b/frontend/src/components/categories/categories-panel.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import React from "react";
+import { useEffect, useState } from "react";
+
+import {
+  CategoryForm,
+  DEFAULT_CATEGORY_FORM_VALUES,
+} from "@/components/categories/category-form";
+import { getErrorMessage } from "@/lib/auth/errors";
+import {
+  archiveCategory,
+  createCategory,
+  listCategories,
+  updateCategory,
+} from "@/lib/categories/api";
+import { CATEGORY_TYPE_LABELS, getSelectableCategories } from "@/lib/categories/presentation";
+import type { Category, CategoryCreatePayload } from "@/lib/categories/types";
+
+type CategoriesPanelProps = {
+  workspaceId: string;
+};
+
+type Notice = {
+  type: "error" | "success";
+  message: string;
+};
+
+function toCategoryFormDefaults(category: Category) {
+  return {
+    name: category.name,
+    type: category.type,
+    icon: category.icon,
+    color: category.color,
+  } as const;
+}
+
+export function CategoriesPanel({ workspaceId }: CategoriesPanelProps) {
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [editingCategoryId, setEditingCategoryId] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [notice, setNotice] = useState<Notice | null>(null);
+
+  const loadCategories = React.useCallback(async () => {
+    setIsLoading(true);
+
+    try {
+      const response = await listCategories(workspaceId);
+      setCategories(getSelectableCategories(response.categories));
+    } catch (error) {
+      setNotice({ type: "error", message: getErrorMessage(error) });
+    } finally {
+      setIsLoading(false);
+    }
+  }, [workspaceId]);
+
+  useEffect(() => {
+    setEditingCategoryId(null);
+    setNotice(null);
+
+    void loadCategories();
+  }, [loadCategories]);
+
+  const handleCreate = async (payload: CategoryCreatePayload) => {
+    setNotice(null);
+
+    try {
+      const category = await createCategory(workspaceId, payload);
+      setCategories((currentCategories) => getSelectableCategories([category, ...currentCategories]));
+      setNotice({ type: "success", message: `Categoria ${category.name} creada correctamente.` });
+      return true;
+    } catch (error) {
+      setNotice({ type: "error", message: getErrorMessage(error) });
+      return false;
+    }
+  };
+
+  const handleUpdate = async (categoryId: string, payload: CategoryCreatePayload) => {
+    setNotice(null);
+
+    try {
+      const updatedCategory = await updateCategory(workspaceId, categoryId, payload);
+      setCategories((currentCategories) =>
+        getSelectableCategories(
+          currentCategories.map((category) =>
+            category.id === updatedCategory.id ? updatedCategory : category,
+          ),
+        ),
+      );
+      setNotice({ type: "success", message: `Categoria ${updatedCategory.name} actualizada.` });
+      return true;
+    } catch (error) {
+      setNotice({ type: "error", message: getErrorMessage(error) });
+      return false;
+    }
+  };
+
+  const handleArchive = async (category: Category) => {
+    const shouldArchive = window.confirm(
+      `Vas a archivar la categoria ${category.name}. Dejara de aparecer en los selectores activos.`,
+    );
+
+    if (!shouldArchive) {
+      return;
+    }
+
+    setNotice(null);
+
+    try {
+      const archivedCategory = await archiveCategory(workspaceId, category.id);
+      setCategories((currentCategories) =>
+        currentCategories.filter((currentCategory) => currentCategory.id !== archivedCategory.id),
+      );
+      if (editingCategoryId === archivedCategory.id) {
+        setEditingCategoryId(null);
+      }
+      setNotice({ type: "success", message: `Categoria ${archivedCategory.name} archivada.` });
+    } catch (error) {
+      setNotice({ type: "error", message: getErrorMessage(error) });
+    }
+  };
+
+  return (
+    <section className="workspace-panel">
+      <div className="workspace-form-header">
+        <h2 className="workspace-section-title">Categorias</h2>
+        <p className="workspace-section-copy">
+          Las listas y selectores muestran categorias activas por defecto para mantener limpio el flujo.
+        </p>
+      </div>
+
+      {notice ? (
+        <div
+          className={`auth-feedback ${notice.type === "error" ? "auth-feedback-error" : "auth-feedback-success"}`}
+          role={notice.type === "error" ? "alert" : "status"}
+        >
+          {notice.message}
+        </div>
+      ) : null}
+
+      <div className="entity-section">
+        <div className="workspace-form-header">
+          <h3 className="workspace-section-title">Nueva categoria</h3>
+          <p className="workspace-section-copy">
+            Las categorias base sembradas por backend aparecen aqui y puedes ampliarlas segun el espacio.
+          </p>
+        </div>
+        <CategoryForm
+          defaultValues={DEFAULT_CATEGORY_FORM_VALUES}
+          fieldIdPrefix={`category-create-${workspaceId}`}
+          onSubmitCategory={handleCreate}
+          resetOnSuccess
+          submitLabel="Crear categoria"
+          submittingLabel="Guardando..."
+        />
+      </div>
+
+      <div className="entity-list" aria-label="Categorias activas del espacio">
+        {isLoading ? <p className="workspace-section-copy">Cargando categorias...</p> : null}
+
+        {!isLoading && categories.length === 0 ? (
+          <p className="workspace-section-copy">
+            Todavia no hay categorias activas. Crea una para clasificar mejor tus movimientos.
+          </p>
+        ) : null}
+
+        {!isLoading
+          ? categories.map((category) => {
+              const isEditing = editingCategoryId === category.id;
+
+              return (
+                <article key={category.id} className="entity-card">
+                  <div className="entity-card-header">
+                    <div>
+                      <div className="workspace-list-topline">
+                        <strong>{category.name}</strong>
+                        <span className="workspace-role-chip">{CATEGORY_TYPE_LABELS[category.type]}</span>
+                      </div>
+                      <p className="workspace-section-copy">
+                        Icono <code>{category.icon}</code>
+                      </p>
+                    </div>
+                    <div className="entity-card-side">
+                      <span
+                        aria-hidden="true"
+                        className="entity-color-swatch"
+                        style={{ backgroundColor: category.color }}
+                      />
+                      <span className="workspace-member-date">{category.color}</span>
+                    </div>
+                  </div>
+
+                  <div className="entity-actions">
+                    <button
+                      className="secondary-action entity-secondary-action"
+                      onClick={() => setEditingCategoryId(isEditing ? null : category.id)}
+                      type="button"
+                    >
+                      {isEditing ? "Cerrar edicion" : "Editar"}
+                    </button>
+                    <button
+                      className="secondary-action entity-danger-action"
+                      onClick={() => {
+                        void handleArchive(category);
+                      }}
+                      type="button"
+                    >
+                      Archivar
+                    </button>
+                  </div>
+
+                  {isEditing ? (
+                    <div className="entity-inline-form">
+                      <div className="workspace-form-header">
+                        <h3 className="workspace-section-title">Editar categoria</h3>
+                        <p className="workspace-section-copy">
+                          Ajusta nombre, color o icono sin perder la relacion historica con movimientos.
+                        </p>
+                      </div>
+                      <CategoryForm
+                        defaultValues={toCategoryFormDefaults(category)}
+                        fieldIdPrefix={`category-edit-${category.id}`}
+                        onCancel={() => setEditingCategoryId(null)}
+                        onSubmitCategory={(payload) => handleUpdate(category.id, payload)}
+                        submitLabel="Guardar cambios"
+                        submittingLabel="Guardando..."
+                      />
+                    </div>
+                  ) : null}
+                </article>
+              );
+            })
+          : null}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/categories/category-form.tsx
+++ b/frontend/src/components/categories/category-form.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import React from "react";
+import { useEffect, useTransition } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+import { CATEGORY_TYPE_OPTIONS } from "@/lib/categories/presentation";
+import { categoryFormSchema, type CategoryFormValues } from "@/lib/categories/schemas";
+import type { CategoryCreatePayload } from "@/lib/categories/types";
+
+export const DEFAULT_CATEGORY_FORM_VALUES: CategoryFormValues = {
+  name: "",
+  type: "expense",
+  icon: "receipt-text",
+  color: "#D97706",
+};
+
+type CategoryFormProps = {
+  defaultValues?: CategoryFormValues;
+  submitLabel: string;
+  submittingLabel: string;
+  onSubmitCategory: (payload: CategoryCreatePayload) => Promise<boolean>;
+  onCancel?: () => void;
+  resetOnSuccess?: boolean;
+  fieldIdPrefix: string;
+};
+
+export function CategoryForm({
+  defaultValues = DEFAULT_CATEGORY_FORM_VALUES,
+  submitLabel,
+  submittingLabel,
+  onSubmitCategory,
+  onCancel,
+  resetOnSuccess = false,
+  fieldIdPrefix,
+}: CategoryFormProps) {
+  const [isPending, startTransition] = useTransition();
+  const form = useForm<CategoryFormValues>({
+    resolver: zodResolver(categoryFormSchema),
+    defaultValues,
+  });
+
+  useEffect(() => {
+    form.reset(defaultValues);
+  }, [defaultValues, form]);
+
+  const onSubmit = form.handleSubmit((values) => {
+    startTransition(async () => {
+      const isSuccessful = await onSubmitCategory({
+        name: values.name.trim(),
+        type: values.type,
+        icon: values.icon.trim(),
+        color: values.color.trim().toUpperCase(),
+      });
+
+      if (!isSuccessful) {
+        return;
+      }
+
+      if (resetOnSuccess) {
+        form.reset(DEFAULT_CATEGORY_FORM_VALUES);
+      }
+
+      onCancel?.();
+    });
+  });
+
+  return (
+    <form className="workspace-form" onSubmit={onSubmit} noValidate>
+      <div className="entity-split-grid">
+        <label className="auth-field" htmlFor={`${fieldIdPrefix}-name`}>
+          <span className="auth-label">Nombre</span>
+          <input
+            id={`${fieldIdPrefix}-name`}
+            className="auth-input"
+            type="text"
+            placeholder="Ej. Alimentacion"
+            aria-invalid={Boolean(form.formState.errors.name)}
+            {...form.register("name")}
+          />
+          {form.formState.errors.name ? (
+            <span className="auth-field-error">{form.formState.errors.name.message}</span>
+          ) : null}
+        </label>
+
+        <label className="auth-field" htmlFor={`${fieldIdPrefix}-type`}>
+          <span className="auth-label">Tipo</span>
+          <select
+            id={`${fieldIdPrefix}-type`}
+            className="auth-input"
+            aria-invalid={Boolean(form.formState.errors.type)}
+            {...form.register("type")}
+          >
+            {CATEGORY_TYPE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          {form.formState.errors.type ? (
+            <span className="auth-field-error">{form.formState.errors.type.message}</span>
+          ) : null}
+        </label>
+
+        <label className="auth-field" htmlFor={`${fieldIdPrefix}-icon`}>
+          <span className="auth-label">Icono</span>
+          <input
+            id={`${fieldIdPrefix}-icon`}
+            className="auth-input"
+            type="text"
+            placeholder="receipt-text"
+            aria-invalid={Boolean(form.formState.errors.icon)}
+            {...form.register("icon")}
+          />
+          {form.formState.errors.icon ? (
+            <span className="auth-field-error">{form.formState.errors.icon.message}</span>
+          ) : null}
+        </label>
+
+        <label className="auth-field" htmlFor={`${fieldIdPrefix}-color`}>
+          <span className="auth-label">Color</span>
+          <input
+            id={`${fieldIdPrefix}-color`}
+            className="auth-input"
+            type="text"
+            placeholder="#D97706"
+            aria-invalid={Boolean(form.formState.errors.color)}
+            {...form.register("color")}
+          />
+          {form.formState.errors.color ? (
+            <span className="auth-field-error">{form.formState.errors.color.message}</span>
+          ) : null}
+        </label>
+      </div>
+
+      <div className="entity-actions">
+        <button className="primary-action entity-submit" type="submit" disabled={isPending}>
+          {isPending ? submittingLabel : submitLabel}
+        </button>
+        {onCancel ? (
+          <button className="secondary-action entity-secondary-action" onClick={onCancel} type="button">
+            Cancelar
+          </button>
+        ) : null}
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/components/workspaces/workspace-dashboard.test.tsx
+++ b/frontend/src/components/workspaces/workspace-dashboard.test.tsx
@@ -5,6 +5,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { WorkspaceDashboard } from "@/components/workspaces/workspace-dashboard";
 
+vi.mock("@/components/accounts/accounts-panel", () => ({
+  AccountsPanel: ({ workspaceId }: { workspaceId: string }) => <div>Panel cuentas {workspaceId}</div>,
+}));
+
+vi.mock("@/components/categories/categories-panel", () => ({
+  CategoriesPanel: ({ workspaceId }: { workspaceId: string }) => <div>Panel categorias {workspaceId}</div>,
+}));
+
 const replaceMock = vi.fn();
 const refreshMock = vi.fn();
 
@@ -123,6 +131,8 @@ describe("WorkspaceDashboard", () => {
     expect(screen.getByRole("button", { name: /crear invitacion/i })).toBeInTheDocument();
     expect(screen.getAllByText("owner@example.com")).toHaveLength(2);
     expect(screen.getByText("ana@example.com")).toBeInTheDocument();
+    expect(screen.getByText("Panel cuentas workspace-1")).toBeInTheDocument();
+    expect(screen.getByText("Panel categorias workspace-1")).toBeInTheDocument();
   });
 
   it("hides owner-only invitation controls for members", async () => {

--- a/frontend/src/components/workspaces/workspace-dashboard.tsx
+++ b/frontend/src/components/workspaces/workspace-dashboard.tsx
@@ -5,6 +5,8 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useState, useTransition } from "react";
 
+import { AccountsPanel } from "@/components/accounts/accounts-panel";
+import { CategoriesPanel } from "@/components/categories/categories-panel";
 import { WorkspaceCreateForm } from "@/components/workspaces/workspace-create-form";
 import { WorkspaceInvitationsPanel } from "@/components/workspaces/workspace-invitations-panel";
 import { WorkspaceList } from "@/components/workspaces/workspace-list";
@@ -296,6 +298,8 @@ export function WorkspaceDashboard({ user, initialWorkspaceId = null }: Workspac
               <>
                 {isRefreshingWorkspace ? <div className="workspace-loading-bar">Actualizando datos...</div> : null}
                 <WorkspaceSummary workspace={selectedWorkspace} onRename={handleRenameWorkspace} />
+                <AccountsPanel workspaceId={selectedWorkspace.id} />
+                <CategoriesPanel workspaceId={selectedWorkspace.id} />
                 <WorkspaceMembersList members={members} />
                 <WorkspaceInvitationsPanel
                   workspace={selectedWorkspace}

--- a/frontend/src/lib/accounts/api.ts
+++ b/frontend/src/lib/accounts/api.ts
@@ -1,0 +1,46 @@
+import { requestJson } from "@/lib/api/client";
+import type {
+  Account,
+  AccountCreatePayload,
+  AccountListResponse,
+  AccountUpdatePayload,
+} from "@/lib/accounts/types";
+
+type ListAccountsOptions = {
+  includeArchived?: boolean;
+};
+
+export function listAccounts(
+  workspaceId: string,
+  options: ListAccountsOptions = {},
+): Promise<AccountListResponse> {
+  const query = options.includeArchived ? "?include_archived=true" : "";
+
+  return requestJson<AccountListResponse>(`/workspaces/${workspaceId}/accounts${query}`, {
+    method: "GET",
+  });
+}
+
+export function createAccount(workspaceId: string, payload: AccountCreatePayload): Promise<Account> {
+  return requestJson<Account>(`/workspaces/${workspaceId}/accounts`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export function updateAccount(
+  workspaceId: string,
+  accountId: string,
+  payload: AccountUpdatePayload,
+): Promise<Account> {
+  return requestJson<Account>(`/workspaces/${workspaceId}/accounts/${accountId}`, {
+    method: "PATCH",
+    body: JSON.stringify(payload),
+  });
+}
+
+export function archiveAccount(workspaceId: string, accountId: string): Promise<Account> {
+  return requestJson<Account>(`/workspaces/${workspaceId}/accounts/${accountId}/archive`, {
+    method: "POST",
+  });
+}

--- a/frontend/src/lib/accounts/presentation.ts
+++ b/frontend/src/lib/accounts/presentation.ts
@@ -1,0 +1,55 @@
+import type { AccountType } from "@/lib/accounts/types";
+import type { AccountFormValues } from "@/lib/accounts/schemas";
+
+export const ACCOUNT_TYPE_LABELS: Record<AccountType, string> = {
+  cash: "Efectivo",
+  bank_account: "Cuenta bancaria",
+  savings_account: "Cuenta de ahorro",
+  credit_card: "Tarjeta de credito",
+};
+
+export const ACCOUNT_TYPE_OPTIONS: Array<{ value: AccountType; label: string }> = [
+  { value: "cash", label: ACCOUNT_TYPE_LABELS.cash },
+  { value: "bank_account", label: ACCOUNT_TYPE_LABELS.bank_account },
+  { value: "savings_account", label: ACCOUNT_TYPE_LABELS.savings_account },
+  { value: "credit_card", label: ACCOUNT_TYPE_LABELS.credit_card },
+];
+
+export function parseMoneyInputToMinorUnits(value: string): number {
+  const normalizedValue = value.trim().replace(",", ".");
+  const isNegative = normalizedValue.startsWith("-");
+  const unsignedValue = isNegative ? normalizedValue.slice(1) : normalizedValue;
+  const [wholePart, decimalPart = ""] = unsignedValue.split(".");
+  const paddedDecimals = `${decimalPart}00`.slice(0, 2);
+  const minorUnits = Number.parseInt(wholePart, 10) * 100 + Number.parseInt(paddedDecimals, 10);
+
+  return isNegative ? -minorUnits : minorUnits;
+}
+
+export function formatMinorUnitsAsCurrency(value: number, currency: string): string {
+  return new Intl.NumberFormat("es-ES", {
+    style: "currency",
+    currency,
+  }).format(value / 100);
+}
+
+export function formatMinorUnitsForInput(value: number): string {
+  const sign = value < 0 ? "-" : "";
+  const absoluteValue = Math.abs(value);
+  const wholePart = Math.trunc(absoluteValue / 100);
+  const decimalPart = `${absoluteValue % 100}`.padStart(2, "0");
+
+  return `${sign}${wholePart}.${decimalPart}`;
+}
+
+export function buildAccountPayload(values: AccountFormValues) {
+  const trimmedDescription = values.description?.trim() ?? "";
+
+  return {
+    name: values.name.trim(),
+    type: values.type,
+    currency: values.currency.trim().toUpperCase(),
+    initial_balance_minor: parseMoneyInputToMinorUnits(values.initialBalance),
+    description: trimmedDescription.length > 0 ? trimmedDescription : null,
+  };
+}

--- a/frontend/src/lib/accounts/schemas.ts
+++ b/frontend/src/lib/accounts/schemas.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+export const accountFormSchema = z.object({
+  name: z.string().trim().min(1, "Indica un nombre para la cuenta.").max(120),
+  type: z.enum(["cash", "bank_account", "savings_account", "credit_card"]),
+  currency: z
+    .string()
+    .trim()
+    .min(3, "Usa un codigo ISO de 3 letras.")
+    .max(3, "Usa un codigo ISO de 3 letras.")
+    .regex(/^[a-zA-Z]{3}$/, "Usa un codigo ISO de 3 letras."),
+  initialBalance: z
+    .string()
+    .trim()
+    .min(1, "Indica el saldo inicial.")
+    .regex(/^-?\d+(?:[.,]\d{1,2})?$/, "Introduce un importe valido con hasta 2 decimales."),
+  description: z.string().trim().max(1000, "La descripcion no puede superar 1000 caracteres.").optional(),
+});
+
+export type AccountFormValues = z.infer<typeof accountFormSchema>;

--- a/frontend/src/lib/accounts/types.ts
+++ b/frontend/src/lib/accounts/types.ts
@@ -1,0 +1,30 @@
+export type AccountType = "cash" | "bank_account" | "savings_account" | "credit_card";
+
+export type Account = {
+  id: string;
+  workspace_id: string;
+  name: string;
+  type: AccountType;
+  currency: string;
+  initial_balance_minor: number;
+  current_balance_minor: number;
+  description: string | null;
+  archived_at: string | null;
+  is_archived: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+export type AccountListResponse = {
+  accounts: Account[];
+};
+
+export type AccountCreatePayload = {
+  name: string;
+  type: AccountType;
+  currency: string;
+  initial_balance_minor: number;
+  description?: string | null;
+};
+
+export type AccountUpdatePayload = Partial<AccountCreatePayload>;

--- a/frontend/src/lib/categories/api.ts
+++ b/frontend/src/lib/categories/api.ts
@@ -1,0 +1,46 @@
+import { requestJson } from "@/lib/api/client";
+import type {
+  Category,
+  CategoryCreatePayload,
+  CategoryListResponse,
+  CategoryUpdatePayload,
+} from "@/lib/categories/types";
+
+type ListCategoriesOptions = {
+  includeArchived?: boolean;
+};
+
+export function listCategories(
+  workspaceId: string,
+  options: ListCategoriesOptions = {},
+): Promise<CategoryListResponse> {
+  const query = options.includeArchived ? "?include_archived=true" : "";
+
+  return requestJson<CategoryListResponse>(`/workspaces/${workspaceId}/categories${query}`, {
+    method: "GET",
+  });
+}
+
+export function createCategory(workspaceId: string, payload: CategoryCreatePayload): Promise<Category> {
+  return requestJson<Category>(`/workspaces/${workspaceId}/categories`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export function updateCategory(
+  workspaceId: string,
+  categoryId: string,
+  payload: CategoryUpdatePayload,
+): Promise<Category> {
+  return requestJson<Category>(`/workspaces/${workspaceId}/categories/${categoryId}`, {
+    method: "PATCH",
+    body: JSON.stringify(payload),
+  });
+}
+
+export function archiveCategory(workspaceId: string, categoryId: string): Promise<Category> {
+  return requestJson<Category>(`/workspaces/${workspaceId}/categories/${categoryId}/archive`, {
+    method: "POST",
+  });
+}

--- a/frontend/src/lib/categories/presentation.ts
+++ b/frontend/src/lib/categories/presentation.ts
@@ -1,0 +1,22 @@
+import type { Category, CategoryType } from "@/lib/categories/types";
+
+export const CATEGORY_TYPE_LABELS: Record<CategoryType, string> = {
+  income: "Ingreso",
+  expense: "Gasto",
+};
+
+export const CATEGORY_TYPE_OPTIONS: Array<{ value: CategoryType; label: string }> = [
+  { value: "expense", label: CATEGORY_TYPE_LABELS.expense },
+  { value: "income", label: CATEGORY_TYPE_LABELS.income },
+];
+
+export function getSelectableCategories(
+  categories: Category[],
+  options: { includeArchived?: boolean } = {},
+): Category[] {
+  const visibleCategories = options.includeArchived
+    ? categories
+    : categories.filter((category) => !category.is_archived);
+
+  return [...visibleCategories].sort((left, right) => left.name.localeCompare(right.name, "es"));
+}

--- a/frontend/src/lib/categories/schemas.ts
+++ b/frontend/src/lib/categories/schemas.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const categoryFormSchema = z.object({
+  name: z.string().trim().min(1, "Indica un nombre para la categoria.").max(120),
+  type: z.enum(["income", "expense"]),
+  icon: z.string().trim().min(1, "Indica un icono para la categoria.").max(64),
+  color: z
+    .string()
+    .trim()
+    .min(1, "Indica un color para la categoria.")
+    .max(32)
+    .regex(/^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/, "Usa un color hexadecimal valido."),
+});
+
+export type CategoryFormValues = z.infer<typeof categoryFormSchema>;

--- a/frontend/src/lib/categories/types.ts
+++ b/frontend/src/lib/categories/types.ts
@@ -1,0 +1,27 @@
+export type CategoryType = "income" | "expense";
+
+export type Category = {
+  id: string;
+  workspace_id: string;
+  name: string;
+  type: CategoryType;
+  icon: string;
+  color: string;
+  archived_at: string | null;
+  is_archived: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+export type CategoryListResponse = {
+  categories: Category[];
+};
+
+export type CategoryCreatePayload = {
+  name: string;
+  type: CategoryType;
+  icon: string;
+  color: string;
+};
+
+export type CategoryUpdatePayload = Partial<CategoryCreatePayload>;


### PR DESCRIPTION
## Summary
- Implements accounts CRUD foundation (issue #28)
- Implements categories CRUD foundation with default seeding (issue #29)
- Adds workspace-scoped accounts with types: cash, bank_account, savings_account, credit_card
- Adds workspace-scoped categories with types: income, expense
- Supports archive behavior for both entities
- Integrates accounts and categories panels into workspace dashboard UI

## Checklist
- [x] Functionality: All acceptance criteria from #28 and #29 completed
- [x] Code: Implementation works locally and is integrated on the branch
- [x] Quality: Lint, typecheck, and tests pass
- [x] Testing coverage: Backend tests (35) and frontend tests (18) pass
- [x] Docs: Architecture docs updated with new entities

## Test results
- Backend: 35 passed
- Frontend: 18 passed
- Lint: ✅
- Typecheck: ✅