### PR TITLE
feat(frontend): update color palette to lavender theme

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,20 +1,26 @@
 @import "tailwindcss";
 
 :root {
-  --background: #f6efe5;
-  --foreground: #1f1a17;
-  --surface: rgba(255, 251, 245, 0.8);
-  --surface-strong: rgba(255, 248, 239, 0.92);
-  --surface-border: rgba(86, 62, 34, 0.16);
-  --accent: #b35c2e;
-  --accent-strong: #8d451f;
-  --accent-soft: rgba(179, 92, 46, 0.14);
+  --lavender-purple: #9667e0;
+  --mauve: #d4bbfc;
+  --lavender-veil: #ebd9fc;
+  --lavender-mist: #f2ebfb;
+  --ghost-white: #fbfaff;
+
+  --background: var(--ghost-white);
+  --foreground: #1a1525;
+  --surface: rgba(251, 250, 255, 0.8);
+  --surface-strong: rgba(242, 235, 251, 0.92);
+  --surface-border: rgba(90, 60, 130, 0.16);
+  --accent: var(--lavender-purple);
+  --accent-strong: #7a4bc4;
+  --accent-soft: var(--lavender-veil);
   --success: #1f7a52;
   --success-soft: rgba(31, 122, 82, 0.12);
   --danger: #ab3c2f;
   --danger-soft: rgba(171, 60, 47, 0.12);
-  --muted: #665b51;
-  --shadow: 0 24px 80px rgba(59, 32, 8, 0.16);
+  --muted: #6d647a;
+  --shadow: 0 24px 80px rgba(45, 30, 80, 0.16);
 }
 
 * {
@@ -23,7 +29,7 @@
 
 html {
   font-family: Georgia, "Times New Roman", serif;
-  background: radial-gradient(circle at top, #fff8ef 0%, #f6efe5 54%, #e5d1b8 100%);
+  background: radial-gradient(circle at top, #ffffff 0%, var(--ghost-white) 54%, var(--lavender-mist) 100%);
 }
 
 body {
@@ -32,8 +38,8 @@ body {
   color: var(--foreground);
   background:
     radial-gradient(circle at 12% 18%, rgba(255, 255, 255, 0.76), transparent 24%),
-    radial-gradient(circle at 85% 5%, rgba(179, 92, 46, 0.14), transparent 26%),
-    linear-gradient(180deg, rgba(255, 251, 245, 0.68), rgba(246, 239, 229, 0.94));
+    radial-gradient(circle at 85% 5%, rgba(150, 103, 224, 0.14), transparent 26%),
+    linear-gradient(180deg, rgba(251, 250, 255, 0.68), rgba(242, 235, 251, 0.94));
 }
 
 a {
@@ -83,8 +89,8 @@ textarea {
   overflow: hidden;
   padding: 2rem;
   background:
-    radial-gradient(circle at top right, rgba(179, 92, 46, 0.18), transparent 28%),
-    linear-gradient(180deg, rgba(255, 248, 239, 0.94), rgba(244, 233, 220, 0.9));
+    radial-gradient(circle at top right, rgba(150, 103, 224, 0.18), transparent 28%),
+    linear-gradient(180deg, rgba(242, 235, 251, 0.94), rgba(235, 217, 252, 0.9));
 }
 
 .auth-kicker,
@@ -127,7 +133,7 @@ textarea {
 .auth-panel-points article,
 .dashboard-stat {
   padding: 1rem 1.1rem;
-  border: 1px solid rgba(86, 62, 34, 0.12);
+  border: 1px solid rgba(90, 60, 130, 0.12);
   border-radius: 22px;
   background: rgba(255, 255, 255, 0.45);
 }
@@ -168,7 +174,7 @@ textarea {
 .auth-input {
   width: 100%;
   padding: 0.9rem 1rem;
-  border: 1px solid rgba(86, 62, 34, 0.18);
+  border: 1px solid rgba(90, 60, 130, 0.18);
   border-radius: 18px;
   background: rgba(255, 255, 255, 0.72);
   color: var(--foreground);
@@ -183,7 +189,7 @@ textarea {
 .auth-input:focus {
   outline: none;
   border-color: var(--accent);
-  box-shadow: 0 0 0 4px rgba(179, 92, 46, 0.12);
+  box-shadow: 0 0 0 4px rgba(150, 103, 224, 0.12);
 }
 
 .auth-input[aria-invalid="true"] {
@@ -206,7 +212,7 @@ textarea {
 .auth-feedback code {
   padding: 0.15rem 0.35rem;
   border-radius: 8px;
-  background: rgba(31, 26, 23, 0.08);
+  background: rgba(26, 21, 37, 0.08);
 }
 
 .auth-feedback-error {
@@ -337,7 +343,7 @@ textarea {
   gap: 0.8rem;
   align-items: flex-start;
   padding: 0.95rem 1rem;
-  border: 1px solid rgba(86, 62, 34, 0.14);
+  border: 1px solid rgba(90, 60, 130, 0.14);
   border-radius: 20px;
   background: rgba(255, 255, 255, 0.52);
 }
@@ -367,7 +373,7 @@ textarea {
   gap: 0.55rem;
   width: 100%;
   padding: 1rem;
-  border: 1px solid rgba(86, 62, 34, 0.14);
+  border: 1px solid rgba(90, 60, 130, 0.14);
   border-radius: 22px;
   background: rgba(255, 255, 255, 0.48);
   text-align: left;
@@ -377,8 +383,8 @@ textarea {
 
 .workspace-list-item:hover,
 .workspace-list-item-active {
-  border-color: rgba(179, 92, 46, 0.36);
-  background: rgba(255, 248, 239, 0.86);
+  border-color: rgba(150, 103, 224, 0.36);
+  background: rgba(242, 235, 251, 0.86);
   transform: translateY(-1px);
 }
 
@@ -449,7 +455,7 @@ textarea {
   gap: 0.8rem 1rem;
   justify-content: space-between;
   padding: 1rem 1.1rem;
-  border: 1px solid rgba(86, 62, 34, 0.12);
+  border: 1px solid rgba(90, 60, 130, 0.12);
   border-radius: 22px;
   background: rgba(255, 255, 255, 0.48);
 }
@@ -495,14 +501,14 @@ textarea {
 .entity-section {
   margin-top: 1.5rem;
   padding-top: 1.5rem;
-  border-top: 1px solid rgba(86, 62, 34, 0.12);
+  border-top: 1px solid rgba(90, 60, 130, 0.12);
 }
 
 .entity-card {
   display: grid;
   gap: 1rem;
   padding: 1.1rem;
-  border: 1px solid rgba(86, 62, 34, 0.12);
+  border: 1px solid rgba(90, 60, 130, 0.12);
   border-radius: 24px;
   background: rgba(255, 255, 255, 0.44);
 }
@@ -553,7 +559,7 @@ textarea {
 .entity-color-swatch {
   width: 2.25rem;
   height: 2.25rem;
-  border: 2px solid rgba(86, 62, 34, 0.16);
+  border: 2px solid rgba(90, 60, 130, 0.16);
   border-radius: 999px;
   box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.12);
 }
@@ -563,7 +569,7 @@ textarea {
 }
 
 .transaction-type-chip {
-  border: 1px solid rgba(86, 62, 34, 0.12);
+  border: 1px solid rgba(90, 60, 130, 0.12);
 }
 
 .transaction-type-chip-income {
@@ -608,7 +614,7 @@ textarea {
 
 .transaction-detail-panel {
   padding-top: 1rem;
-  border-top: 1px solid rgba(86, 62, 34, 0.12);
+  border-top: 1px solid rgba(90, 60, 130, 0.12);
 }
 
 .transaction-detail-grid {
@@ -621,7 +627,7 @@ textarea {
   display: grid;
   gap: 0.2rem;
   padding: 0.9rem 1rem;
-  border: 1px solid rgba(86, 62, 34, 0.1);
+  border: 1px solid rgba(90, 60, 130, 0.1);
   border-radius: 18px;
   background: rgba(255, 255, 255, 0.42);
 }
@@ -724,13 +730,13 @@ textarea {
 
 .primary-action {
   background: var(--accent);
-  color: #fdfaf4;
-  box-shadow: 0 16px 32px rgba(179, 92, 46, 0.2);
+  color: #ffffff;
+  box-shadow: 0 16px 32px rgba(150, 103, 224, 0.2);
   border: 0;
 }
 
 .secondary-action {
-  border: 1px solid rgba(95, 78, 54, 0.18);
+  border: 1px solid rgba(90, 60, 130, 0.18);
   background: rgba(255, 255, 255, 0.54);
 }
 
@@ -746,7 +752,7 @@ textarea {
 
 .stat-card {
   padding: 1.2rem;
-  border: 1px solid rgba(95, 78, 54, 0.14);
+  border: 1px solid rgba(90, 60, 130, 0.14);
   border-radius: 24px;
   background: rgba(255, 255, 255, 0.48);
 }


### PR DESCRIPTION
## Summary
- Updated frontend CSS color palette to use lavender theme
- Added new CSS variables for the lavender palette (lavender-purple, mauve, lavender-veil, lavender-mist, ghost-white)
- Updated all theme colors (background, foreground, accent, surface, shadows) to use the new palette
- Adjusted gradients, borders, and interactive states to match the lavender aesthetic