### PR TITLE
feat: database schema migration for split logic (#5)

### DIFF
--- a/backend/alembic/versions/20260322_000008_seed_default_shared_workspace.py
+++ b/backend/alembic/versions/20260322_000008_seed_default_shared_workspace.py
@@ -1,0 +1,137 @@
+"""seed default shared workspace for existing users
+
+Revision ID: 20260322_000008
+Revises: 20260311_000007
+Create Date: 2026-03-22 00:00:08
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20260322_000008"
+down_revision = "20260311_000007"
+branch_labels = None
+depends_on = None
+
+DEFAULT_CATEGORIES = [
+    ("Comida", "expense", "utensils-crossed", "#D97706"),
+    ("Compras", "expense", "shopping-bag", "#DB2777"),
+    ("Hogar", "expense", "house", "#2563EB"),
+    ("Transporte", "expense", "car-front", "#0891B2"),
+    ("Salud", "expense", "heart-pulse", "#DC2626"),
+    ("Entretenimiento", "expense", "film", "#7C3AED"),
+    ("Servicios", "expense", "receipt-text", "#4B5563"),
+    ("Gastos financieros", "expense", "landmark", "#0F766E"),
+    ("Salario", "income", "briefcase-business", "#15803D"),
+    ("Freelance", "income", "laptop-minimal", "#16A34A"),
+    ("Inversiones", "income", "chart-column", "#65A30D"),
+    ("Otros ingresos", "income", "wallet", "#059669"),
+]
+
+
+def upgrade() -> None:
+    """Create a default shared workspace for each user who doesn't have one."""
+    bind = op.get_bind()
+
+    users_result = sa.text("SELECT id FROM users").execute(bind)
+    user_ids = [row[0] for row in users_result]
+
+    for user_id in user_ids:
+        existing = (
+            sa.text(
+                "SELECT 1 FROM workspace_members wm "
+                "JOIN workspaces w ON w.id = wm.workspace_id "
+                "WHERE wm.user_id = :user_id AND w.type = 'shared' "
+                "LIMIT 1"
+            )
+            .execute(bind, {"user_id": user_id})
+            .first()
+        )
+
+        if existing is not None:
+            continue
+
+        workspace_id = uuid.uuid4()
+        now = datetime.now(UTC)
+
+        sa.text(
+            "INSERT INTO workspaces (id, name, type, created_by_user_id, created_at, updated_at) "
+            "VALUES (:id, :name, :type, :created_by, :now, :now)"
+        ).execute(
+            bind,
+            {
+                "id": workspace_id,
+                "name": "Gastos compartidos",
+                "type": "shared",
+                "created_by": user_id,
+                "now": now,
+            },
+        )
+
+        member_id = uuid.uuid4()
+        sa.text(
+            "INSERT INTO workspace_members "
+            "(id, workspace_id, user_id, role, created_at, updated_at) "
+            "VALUES (:id, :workspace_id, :user_id, :role, :now, :now)"
+        ).execute(
+            bind,
+            {
+                "id": member_id,
+                "workspace_id": workspace_id,
+                "user_id": user_id,
+                "role": "owner",
+                "now": now,
+            },
+        )
+
+        _seed_default_categories(bind, workspace_id, now)
+
+
+def _seed_default_categories(
+    bind: sa.engine.Connection,
+    workspace_id: uuid.UUID,
+    now: datetime,
+) -> None:
+    """Seed default categories matching DEFAULT_WORKSPACE_CATEGORY_SEEDS."""
+    for name, cat_type, icon, color in DEFAULT_CATEGORIES:
+        category_id = uuid.uuid4()
+        sa.text(
+            "INSERT INTO categories "
+            "(id, workspace_id, name, type, icon, color, created_at, updated_at) "
+            "VALUES (:id, :workspace_id, :name, :type, :icon, :color, :now, :now)"
+        ).execute(
+            bind,
+            {
+                "id": category_id,
+                "workspace_id": workspace_id,
+                "name": name,
+                "type": cat_type,
+                "icon": icon,
+                "color": color,
+                "now": now,
+            },
+        )
+
+
+def downgrade() -> None:
+    """Remove seeded shared workspaces (only those named 'Gastos compartidos')."""
+    bind = op.get_bind()
+
+    workspaces = sa.text("SELECT id FROM workspaces WHERE name = 'Gastos compartidos'").execute(
+        bind
+    )
+
+    for (workspace_id,) in workspaces:
+        sa.text("DELETE FROM categories WHERE workspace_id = :wid").execute(
+            bind, {"wid": workspace_id}
+        )
+        sa.text("DELETE FROM workspace_members WHERE workspace_id = :wid").execute(
+            bind, {"wid": workspace_id}
+        )
+        sa.text("DELETE FROM workspaces WHERE id = :wid").execute(bind, {"wid": workspace_id})

--- a/backend/src/app/api/dependencies/net_balances.py
+++ b/backend/src/app/api/dependencies/net_balances.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from fastapi import Depends
+from sqlalchemy.orm import Session
+
+from app.api.dependencies.workspaces import get_workspace_service
+from app.db.session import get_db_session
+from app.services.net_balances import NetBalanceService
+from app.services.workspaces import WorkspaceService
+
+
+def get_net_balance_service(
+    session: Session = Depends(get_db_session),
+    workspace_service: WorkspaceService = Depends(get_workspace_service),
+) -> NetBalanceService:
+    return NetBalanceService(
+        session=session,
+        workspace_service=workspace_service,
+    )

--- a/backend/src/app/api/routes/net_balances.py
+++ b/backend/src/app/api/routes/net_balances.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+
+from app.api.dependencies.auth import get_current_user
+from app.api.dependencies.net_balances import get_net_balance_service
+from app.db.models import User
+from app.schemas.net_balances import NetBalanceEntry, NetBalanceResponse, NetBalanceUserSummary
+from app.services.net_balances import NetBalanceService
+
+router = APIRouter(prefix="/workspaces/{workspace_id}/net-balances", tags=["net-balances"])
+
+
+@router.get("", response_model=NetBalanceResponse)
+def get_net_balances(
+    workspace_id: UUID,
+    user_id: UUID | None = None,
+    current_user: User = Depends(get_current_user),
+    net_balance_service: NetBalanceService = Depends(get_net_balance_service),
+) -> NetBalanceResponse:
+    entries = net_balance_service.get_net_balances(
+        workspace_id=workspace_id,
+        current_user=current_user,
+        filter_user_id=user_id,
+    )
+    return NetBalanceResponse(
+        balances=[
+            NetBalanceEntry(
+                debtor_id=entry.debtor_id,
+                creditor_id=entry.creditor_id,
+                amount_minor=entry.amount_minor,
+                currency=entry.currency,
+                debtor=NetBalanceUserSummary(id=entry.debtor_id, email=entry.debtor_email),
+                creditor=NetBalanceUserSummary(id=entry.creditor_id, email=entry.creditor_email),
+            )
+            for entry in entries
+        ]
+    )

--- a/backend/src/app/api/routes/transactions.py
+++ b/backend/src/app/api/routes/transactions.py
@@ -40,12 +40,14 @@ def create_transaction(
 @router.get("", response_model=TransactionListResponse)
 def list_transactions(
     workspace_id: UUID,
+    user_id: UUID | None = None,
     current_user: User = Depends(get_current_user),
     transaction_service: TransactionService = Depends(get_transaction_service),
 ) -> TransactionListResponse:
     transactions = transaction_service.list_transactions(
         workspace_id=workspace_id,
         current_user=current_user,
+        filter_user_id=user_id,
     )
     return TransactionListResponse(
         transactions=[_build_transaction_response(transaction) for transaction in transactions]

--- a/backend/src/app/main.py
+++ b/backend/src/app/main.py
@@ -5,6 +5,7 @@ from app.api.routes.accounts import router as accounts_router
 from app.api.routes.auth import router as auth_router
 from app.api.routes.categories import router as categories_router
 from app.api.routes.health import router as health_router
+from app.api.routes.net_balances import router as net_balances_router
 from app.api.routes.transactions import router as transactions_router
 from app.api.routes.workspaces import router as workspaces_router
 from app.core.config import Settings, get_settings
@@ -34,6 +35,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(accounts_router, prefix=app_settings.api_v1_prefix)
     app.include_router(categories_router, prefix=app_settings.api_v1_prefix)
     app.include_router(transactions_router, prefix=app_settings.api_v1_prefix)
+    app.include_router(net_balances_router, prefix=app_settings.api_v1_prefix)
 
     return app
 

--- a/backend/src/app/repositories/net_balances.py
+++ b/backend/src/app/repositories/net_balances.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.db.models import Transaction, TransactionType
+
+
+class NetBalanceRepository:
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def compute_pairwise_net(self, *, workspace_id: UUID) -> dict[tuple[UUID, UUID, str], int]:
+        """Compute net pairwise balances for a workspace.
+
+        Returns a dict mapping (debtor_id, creditor_id, currency) -> amount_minor.
+        Positive values mean debtor owes creditor.
+        """
+        statement = (
+            select(Transaction)
+            .where(
+                Transaction.workspace_id == workspace_id,
+                Transaction.type == TransactionType.EXPENSE,
+                Transaction.split_config.is_not(None),
+                Transaction.paid_by_user_id.is_not(None),
+            )
+            .order_by(Transaction.occurred_at.asc())
+        )
+        transactions = list(self._session.scalars(statement).all())
+
+        # Accumulate gross debts: (debtor, creditor, currency) -> amount
+        gross: dict[tuple[UUID, UUID, str], int] = {}
+        for txn in transactions:
+            payer = txn.paid_by_user_id
+            if payer is None or txn.split_config is None:
+                continue
+
+            config: dict[str, Any] = txn.split_config
+            split_type = str(config.get("type", "equal"))
+            values = config.get("values")
+            typed_values: dict[str, Any] | None = values if isinstance(values, dict) else None
+            amount = txn.amount_minor
+            currency = txn.currency
+
+            shares = self._compute_shares(
+                split_type=split_type,
+                values=typed_values,
+                amount_minor=amount,
+                payer_id=payer,
+            )
+
+            for participant_id, share_amount in shares.items():
+                if participant_id == payer:
+                    continue  # Payer doesn't owe themselves
+                if share_amount <= 0:
+                    continue
+                key = (participant_id, payer, currency)
+                gross[key] = gross.get(key, 0) + share_amount
+
+        # Net out bilateral debts
+        net: dict[tuple[UUID, UUID, str], int] = {}
+        processed_pairs: set[tuple[UUID, UUID, str]] = set()
+
+        for (debtor, creditor, currency), amount in gross.items():
+            canonical = (debtor, creditor, currency)
+            reverse = (creditor, debtor, currency)
+
+            if (creditor, debtor, currency) in processed_pairs:
+                continue
+            processed_pairs.add(canonical)
+            processed_pairs.add(reverse)
+
+            reverse_amount = gross.get(reverse, 0)
+            if amount > reverse_amount:
+                net[canonical] = amount - reverse_amount
+            elif reverse_amount > amount:
+                net[reverse] = reverse_amount - amount
+            # If equal, no net debt
+
+        return net
+
+    @staticmethod
+    def _compute_shares(
+        *,
+        split_type: str,
+        values: dict[str, Any] | None,
+        amount_minor: int,
+        payer_id: UUID,
+    ) -> dict[UUID, int]:
+        """Compute each participant's share of the transaction amount."""
+        if split_type == "equal":
+            if values:
+                participant_ids = [UUID(uid) for uid in values.keys()]
+            else:
+                participant_ids = [payer_id]
+
+            n = len(participant_ids)
+            if n == 0:
+                return {payer_id: amount_minor}
+
+            base_share = amount_minor // n
+            remainder = amount_minor % n
+
+            shares: dict[UUID, int] = {}
+            for i, uid in enumerate(participant_ids):
+                shares[uid] = base_share + (1 if i < remainder else 0)
+            return shares
+
+        if split_type == "percentage":
+            if not values:
+                return {payer_id: amount_minor}
+            shares = {}
+            for uid_str, pct in values.items():
+                uid = UUID(uid_str)
+                shares[uid] = round(amount_minor * int(pct) / 100)
+            return shares
+
+        if split_type == "exact":
+            if not values:
+                return {payer_id: amount_minor}
+            shares = {}
+            for uid_str, amt in values.items():
+                uid = UUID(uid_str)
+                shares[uid] = int(amt)
+            return shares
+
+        return {payer_id: amount_minor}

--- a/backend/src/app/repositories/transactions.py
+++ b/backend/src/app/repositories/transactions.py
@@ -55,6 +55,21 @@ class TransactionRepository:
         )
         return list(self._session.scalars(statement).all())
 
+    def list_by_workspace_and_user(self, *, workspace_id: UUID, user_id: UUID) -> list[Transaction]:
+        statement = (
+            self._base_query()
+            .where(Transaction.workspace_id == workspace_id)
+            .order_by(Transaction.occurred_at.desc(), Transaction.created_at.desc())
+        )
+        all_transactions = list(self._session.scalars(statement).all())
+        user_id_str = str(user_id)
+        return [
+            t
+            for t in all_transactions
+            if t.paid_by_user_id == user_id
+            or self._user_in_split_values(t.split_config, user_id_str)
+        ]
+
     def get_by_id(self, *, workspace_id: UUID, transaction_id: UUID) -> Transaction | None:
         statement = self._base_query().where(
             Transaction.workspace_id == workspace_id,
@@ -158,6 +173,15 @@ class TransactionRepository:
             for account_id, total in self._session.execute(statement).all()
             if account_id is not None
         }
+
+    @staticmethod
+    def _user_in_split_values(split_config: dict[str, object] | None, user_id_str: str) -> bool:
+        if split_config is None:
+            return False
+        values = split_config.get("values")
+        if not isinstance(values, dict):
+            return False
+        return user_id_str in values
 
     @staticmethod
     def _base_query() -> Select[tuple[Transaction]]:

--- a/backend/src/app/schemas/net_balances.py
+++ b/backend/src/app/schemas/net_balances.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+class NetBalanceUserSummary(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    email: str
+
+
+class NetBalanceEntry(BaseModel):
+    debtor_id: UUID
+    creditor_id: UUID
+    amount_minor: int
+    currency: str
+    debtor: NetBalanceUserSummary | None = None
+    creditor: NetBalanceUserSummary | None = None
+
+
+class NetBalanceResponse(BaseModel):
+    balances: list[NetBalanceEntry]

--- a/backend/src/app/services/net_balances.py
+++ b/backend/src/app/services/net_balances.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.db.models import User
+from app.repositories.auth import UserRepository
+from app.repositories.net_balances import NetBalanceRepository
+from app.repositories.workspaces import WorkspaceMemberRepository
+from app.services.workspaces import WorkspaceService
+
+
+@dataclass(frozen=True)
+class NetBalanceEntry:
+    debtor_id: UUID
+    creditor_id: UUID
+    amount_minor: int
+    currency: str
+    debtor_email: str
+    creditor_email: str
+
+
+class NetBalanceService:
+    def __init__(
+        self,
+        session: Session,
+        workspace_service: WorkspaceService,
+    ) -> None:
+        self._session = session
+        self._workspace_service = workspace_service
+        self._net_balances = NetBalanceRepository(session)
+        self._members = WorkspaceMemberRepository(session)
+        self._users = UserRepository(session)
+
+    def get_net_balances(
+        self,
+        *,
+        workspace_id: UUID,
+        current_user: User,
+        filter_user_id: UUID | None = None,
+    ) -> list[NetBalanceEntry]:
+        self._workspace_service.get_workspace_access(
+            workspace_id=workspace_id,
+            current_user=current_user,
+        )
+
+        pairwise = self._net_balances.compute_pairwise_net(workspace_id=workspace_id)
+
+        entries: list[NetBalanceEntry] = []
+        for (debtor_id, creditor_id, currency), amount in pairwise.items():
+            if filter_user_id is not None:
+                if debtor_id != filter_user_id and creditor_id != filter_user_id:
+                    continue
+
+            debtor = self._users.get_by_id(debtor_id)
+            creditor = self._users.get_by_id(creditor_id)
+            if debtor is None or creditor is None:
+                continue
+
+            entries.append(
+                NetBalanceEntry(
+                    debtor_id=debtor_id,
+                    creditor_id=creditor_id,
+                    amount_minor=amount,
+                    currency=currency,
+                    debtor_email=debtor.email,
+                    creditor_email=creditor.email,
+                )
+            )
+
+        return entries

--- a/backend/src/app/services/transactions.py
+++ b/backend/src/app/services/transactions.py
@@ -110,11 +110,17 @@ class TransactionService:
             workspace_id=workspace_id, transaction_id=transaction.id
         )
 
-    def list_transactions(self, *, workspace_id: UUID, current_user: User) -> list[Transaction]:
+    def list_transactions(
+        self, *, workspace_id: UUID, current_user: User, filter_user_id: UUID | None = None
+    ) -> list[Transaction]:
         self._workspace_service.get_workspace_access(
             workspace_id=workspace_id,
             current_user=current_user,
         )
+        if filter_user_id is not None:
+            return self._transactions.list_by_workspace_and_user(
+                workspace_id=workspace_id, user_id=filter_user_id
+            )
         return self._transactions.list_by_workspace(workspace_id=workspace_id)
 
     def get_transaction(
@@ -363,7 +369,12 @@ class TransactionService:
         currency = self._normalize_currency(str(payload["currency"]))
         description = self._normalize_description(payload.get("description"))
         occurred_at = self._normalize_occurred_at(payload["occurred_at"])
-        split_config = self._normalize_split_config(payload.get("split_config"))
+        split_config = self._normalize_split_config(
+            payload.get("split_config"),
+            workspace_id=workspace_id,
+            amount_minor=amount_minor,
+            paid_by_user_id=paid_by_user_id,
+        )
 
         account_ids = {
             account_id
@@ -631,9 +642,117 @@ class TransactionService:
             )
         return occurred_at.astimezone(UTC)
 
-    @staticmethod
-    def _normalize_split_config(split_config: dict[str, object] | None) -> dict[str, object] | None:
-        return split_config
+    def _normalize_split_config(
+        self,
+        split_config: dict[str, object] | None,
+        *,
+        workspace_id: UUID,
+        amount_minor: int,
+        paid_by_user_id: UUID | None,
+    ) -> dict[str, object] | None:
+        if split_config is None:
+            return None
+
+        split_type = split_config.get("type")
+        if split_type not in ("equal", "percentage", "exact"):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="split_config.type must be one of: equal, percentage, exact.",
+            )
+
+        if paid_by_user_id is None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="paid_by_user_id is required when split_config is provided.",
+            )
+
+        raw_values = split_config.get("values")
+        if raw_values is not None and not isinstance(raw_values, dict):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="split_config.values must be a dict mapping user UUIDs to integers.",
+            )
+
+        values: dict[str, int] = {}
+        if raw_values is not None:
+            for key, value in raw_values.items():
+                try:
+                    UUID(str(key))
+                except ValueError as err:
+                    raise HTTPException(
+                        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                        detail=f"split_config.values key {key!r} is not a valid UUID.",
+                    ) from err
+                if not isinstance(value, int):
+                    raise HTTPException(
+                        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                        detail=f"split_config.values[{key}] must be an integer.",
+                    )
+                values[str(key)] = value
+
+        # Validate all referenced users are workspace members
+        for user_id_str in values:
+            member_uuid = UUID(user_id_str)
+            membership = self._members.get_for_user(workspace_id=workspace_id, user_id=member_uuid)
+            if membership is None:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=(
+                        f"split_config references user {user_id_str} "
+                        "who is not a member of this workspace."
+                    ),
+                )
+
+        if split_type == "percentage":
+            if not values:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail="Percentage split requires values.",
+                )
+            paid_by_str = str(paid_by_user_id)
+            if paid_by_str not in values:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail="paid_by_user_id must be a participant in percentage split values.",
+                )
+            for user_id_str, pct in values.items():
+                if pct < 0 or pct > 100:
+                    raise HTTPException(
+                        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                        detail=(f"split_config.values[{user_id_str}] must be between 0 and 100."),
+                    )
+            if sum(values.values()) != 100:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail="Percentage split values must sum to 100.",
+                )
+
+        elif split_type == "exact":
+            if not values:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail="Exact split requires values.",
+                )
+            paid_by_str = str(paid_by_user_id)
+            if paid_by_str not in values:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail="paid_by_user_id must be a participant in exact split values.",
+                )
+            for user_id_str, amount in values.items():
+                if amount <= 0:
+                    raise HTTPException(
+                        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                        detail=(f"split_config.values[{user_id_str}] must be greater than zero."),
+                    )
+            if sum(values.values()) != amount_minor:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=(f"Exact split values must sum to {amount_minor}."),
+                )
+
+        # For "equal" type, values are optional/ignored
+        return {"type": split_type, "values": values or None}
 
     @staticmethod
     def _ensure_account_currency_matches(*, account: Account, currency: str) -> None:

--- a/backend/tests/test_net_balances.py
+++ b/backend/tests/test_net_balances.py
@@ -1,0 +1,727 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from pathlib import Path
+from typing import cast
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.api.dependencies.auth import _TEST_REDIS
+from app.api.dependencies.transactions import _TEST_OBJECT_STORAGE
+from app.core.config import get_settings
+from app.db.base import Base
+from app.db.session import get_db_session
+from app.main import create_app
+
+
+@pytest.fixture
+def net_balances_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient]:
+    database_path = tmp_path / "net_balances.db"
+    monkeypatch.setenv("APP_ENV", "test")
+    monkeypatch.setenv("APP_DEBUG", "false")
+    monkeypatch.setenv("API_V1_PREFIX", "/api/v1")
+    monkeypatch.setenv("DATABASE_HOST", "localhost")
+    monkeypatch.setenv("DATABASE_PORT", "5432")
+    monkeypatch.setenv("DATABASE_NAME", "shared_expenses_test")
+    monkeypatch.setenv("DATABASE_USER", "postgres")
+    monkeypatch.setenv("DATABASE_PASSWORD", "postgres")
+    monkeypatch.setenv("DATABASE_ECHO", "false")
+    monkeypatch.setenv("REDIS_HOST", "localhost")
+    monkeypatch.setenv("REDIS_PORT", "6379")
+    monkeypatch.setenv("REDIS_DB", "0")
+    monkeypatch.setenv("REDIS_PASSWORD", "")
+    monkeypatch.setenv("S3_ENDPOINT_URL", "http://localhost:9000")
+    monkeypatch.setenv("S3_REGION", "us-east-1")
+    monkeypatch.setenv("S3_ACCESS_KEY_ID", "minioadmin")
+    monkeypatch.setenv("S3_SECRET_ACCESS_KEY", "minioadmin")
+    monkeypatch.setenv("S3_BUCKET", "transaction-receipts-test")
+    monkeypatch.setenv("S3_USE_SSL", "false")
+    monkeypatch.setenv("S3_FORCE_PATH_STYLE", "true")
+    monkeypatch.setenv("TRANSACTION_RECEIPT_MAX_SIZE_BYTES", str(10 * 1024 * 1024))
+    monkeypatch.setenv("AUTH_COOKIE_SECURE", "false")
+    monkeypatch.setenv("WORKSPACE_INVITATION_TTL_SECONDS", "3600")
+
+    get_settings.cache_clear()
+    settings = get_settings()
+    engine = create_engine(f"sqlite+pysqlite:///{database_path}", future=True)
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    Base.metadata.create_all(engine)
+    _TEST_REDIS._values.clear()
+    _TEST_OBJECT_STORAGE.clear()
+
+    app = create_app(settings)
+
+    def override_db_session() -> Generator[Session]:
+        session = session_factory()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_db_session] = override_db_session
+
+    with TestClient(app) as client:
+        yield client
+
+    app.dependency_overrides.clear()
+    Base.metadata.drop_all(engine)
+
+
+def _sign_up_and_sign_in(client: TestClient, email: str) -> TestClient:
+    session_client = TestClient(cast(FastAPI, client.app))
+    response = session_client.post(
+        "/api/v1/auth/sign-up",
+        json={"email": email, "password": "secret123"},
+    )
+    assert response.status_code == 201
+    response = session_client.post(
+        "/api/v1/auth/sign-in",
+        json={"email": email, "password": "secret123"},
+    )
+    assert response.status_code == 200
+    return session_client
+
+
+def _create_workspace(client: TestClient, *, name: str, workspace_type: str) -> dict[str, str]:
+    response = client.post(
+        "/api/v1/workspaces",
+        json={"name": name, "type": workspace_type},
+    )
+    assert response.status_code == 201
+    return cast(dict[str, str], response.json())
+
+
+def _create_invitation(client: TestClient, *, workspace_id: str, email: str) -> dict[str, str]:
+    response = client.post(
+        f"/api/v1/workspaces/{workspace_id}/invitations",
+        json={"email": email},
+    )
+    assert response.status_code == 201
+    return cast(dict[str, str], response.json())
+
+
+def _accept_invitation(client: TestClient, *, invitation: dict[str, str]) -> None:
+    response = client.post(
+        "/api/v1/workspaces/invitations/accept",
+        json={"token": invitation["invitation_token"]},
+    )
+    assert response.status_code == 200
+
+
+def _create_account(
+    client: TestClient,
+    *,
+    workspace_id: str,
+    name: str,
+    account_type: str,
+    currency: str,
+    initial_balance_minor: int,
+    description: str | None,
+) -> dict[str, object]:
+    response = client.post(
+        f"/api/v1/workspaces/{workspace_id}/accounts",
+        json={
+            "name": name,
+            "type": account_type,
+            "currency": currency,
+            "initial_balance_minor": initial_balance_minor,
+            "description": description,
+        },
+    )
+    assert response.status_code == 201
+    return cast(dict[str, object], response.json())
+
+
+def _find_category_by_name(
+    client: TestClient, *, workspace_id: str, name: str
+) -> dict[str, object]:
+    response = client.get(f"/api/v1/workspaces/{workspace_id}/categories")
+    assert response.status_code == 200
+    for category in response.json()["categories"]:
+        if category["name"] == name:
+            return cast(dict[str, object], category)
+    raise AssertionError(f"Category {name!r} not found")
+
+
+def _get_user_id(client: TestClient) -> str:
+    response = client.get("/api/v1/auth/me")
+    assert response.status_code == 200
+    return cast(str, response.json()["user"]["id"])
+
+
+def _create_expense(
+    client: TestClient,
+    *,
+    workspace_id: str,
+    source_account_id: str,
+    category_id: str,
+    paid_by_user_id: str,
+    amount_minor: int,
+    currency: str,
+    description: str,
+    split_config: dict[str, object] | None = None,
+) -> dict[str, object]:
+    response = client.post(
+        f"/api/v1/workspaces/{workspace_id}/transactions",
+        json={
+            "type": "expense",
+            "source_account_id": source_account_id,
+            "category_id": category_id,
+            "paid_by_user_id": paid_by_user_id,
+            "amount_minor": amount_minor,
+            "currency": currency.lower(),
+            "description": description,
+            "occurred_at": "2026-03-10T12:00:00Z",
+            "split_config": split_config,
+        },
+    )
+    assert response.status_code == 201
+    return cast(dict[str, object], response.json())
+
+
+def _create_transfer(
+    client: TestClient,
+    *,
+    workspace_id: str,
+    source_account_id: str,
+    destination_account_id: str,
+    amount_minor: int,
+    currency: str,
+) -> dict[str, object]:
+    response = client.post(
+        f"/api/v1/workspaces/{workspace_id}/transactions",
+        json={
+            "type": "transfer",
+            "source_account_id": source_account_id,
+            "destination_account_id": destination_account_id,
+            "amount_minor": amount_minor,
+            "currency": currency,
+            "description": "Transfer test",
+            "occurred_at": "2026-03-10T12:00:00Z",
+            "split_config": None,
+        },
+    )
+    assert response.status_code == 201
+    return cast(dict[str, object], response.json())
+
+
+def _create_shared_workspace(
+    owner_client: TestClient,
+    member_client: TestClient,
+    *,
+    workspace_name: str = "Casa",
+) -> dict[str, str]:
+    workspace = _create_workspace(owner_client, name=workspace_name, workspace_type="shared")
+    member_email = member_client.get("/api/v1/auth/me").json()["user"]["email"]
+    invitation = _create_invitation(
+        owner_client,
+        workspace_id=workspace["id"],
+        email=member_email,
+    )
+    _accept_invitation(member_client, invitation=invitation)
+    return workspace
+
+
+def _create_shared_workspace_with_three_members(
+    owner_client: TestClient,
+    member_a_client: TestClient,
+    member_b_client: TestClient,
+) -> dict[str, str]:
+    workspace = _create_workspace(owner_client, name="Tres", workspace_type="shared")
+
+    member_a_email = member_a_client.get("/api/v1/auth/me").json()["user"]["email"]
+    invitation_a = _create_invitation(
+        owner_client,
+        workspace_id=workspace["id"],
+        email=member_a_email,
+    )
+    _accept_invitation(member_a_client, invitation=invitation_a)
+
+    member_b_email = member_b_client.get("/api/v1/auth/me").json()["user"]["email"]
+    invitation_b = _create_invitation(
+        owner_client,
+        workspace_id=workspace["id"],
+        email=member_b_email,
+    )
+    _accept_invitation(member_b_client, invitation=invitation_b)
+
+    return workspace
+
+
+def test_equal_split_produces_correct_net_balance(
+    net_balances_client: TestClient,
+) -> None:
+    owner_client = _sign_up_and_sign_in(net_balances_client, "owner@example.com")
+    member_client = _sign_up_and_sign_in(net_balances_client, "member@example.com")
+    workspace = _create_shared_workspace(owner_client, member_client)
+
+    owner_id = _get_user_id(owner_client)
+    member_id = _get_user_id(member_client)
+
+    owner_account = _create_account(
+        owner_client,
+        workspace_id=workspace["id"],
+        name="Cuenta owner",
+        account_type="bank_account",
+        currency="ars",
+        initial_balance_minor=100000,
+        description=None,
+    )
+    expense_category = _find_category_by_name(
+        owner_client,
+        workspace_id=workspace["id"],
+        name="Comida",
+    )
+
+    _create_expense(
+        owner_client,
+        workspace_id=workspace["id"],
+        source_account_id=cast(str, owner_account["id"]),
+        category_id=cast(str, expense_category["id"]),
+        paid_by_user_id=owner_id,
+        amount_minor=10000,
+        currency="ars",
+        description="Cena compartida",
+        split_config={
+            "type": "equal",
+            "values": {owner_id: 1, member_id: 1},
+        },
+    )
+
+    response = owner_client.get(
+        f"/api/v1/workspaces/{workspace['id']}/net-balances",
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["balances"]) == 1
+    entry = data["balances"][0]
+    assert entry["debtor_id"] == member_id
+    assert entry["creditor_id"] == owner_id
+    assert entry["amount_minor"] == 5000
+    assert entry["currency"] == "ARS"
+    assert entry["debtor"]["email"] == "member@example.com"
+    assert entry["creditor"]["email"] == "owner@example.com"
+
+
+def test_percentage_split_produces_correct_net_balance(
+    net_balances_client: TestClient,
+) -> None:
+    owner_client = _sign_up_and_sign_in(net_balances_client, "owner_pct@example.com")
+    member_client = _sign_up_and_sign_in(net_balances_client, "member_pct@example.com")
+    workspace = _create_shared_workspace(owner_client, member_client)
+
+    owner_id = _get_user_id(owner_client)
+    member_id = _get_user_id(member_client)
+
+    owner_account = _create_account(
+        owner_client,
+        workspace_id=workspace["id"],
+        name="Cuenta owner",
+        account_type="bank_account",
+        currency="ars",
+        initial_balance_minor=100000,
+        description=None,
+    )
+    expense_category = _find_category_by_name(
+        owner_client,
+        workspace_id=workspace["id"],
+        name="Comida",
+    )
+
+    _create_expense(
+        owner_client,
+        workspace_id=workspace["id"],
+        source_account_id=cast(str, owner_account["id"]),
+        category_id=cast(str, expense_category["id"]),
+        paid_by_user_id=owner_id,
+        amount_minor=10000,
+        currency="ars",
+        description="Cena por porcentaje",
+        split_config={
+            "type": "percentage",
+            "values": {owner_id: 70, member_id: 30},
+        },
+    )
+
+    response = owner_client.get(
+        f"/api/v1/workspaces/{workspace['id']}/net-balances",
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["balances"]) == 1
+    entry = data["balances"][0]
+    assert entry["debtor_id"] == member_id
+    assert entry["creditor_id"] == owner_id
+    assert entry["amount_minor"] == 3000
+    assert entry["currency"] == "ARS"
+
+
+def test_multiple_transactions_net_correctly(
+    net_balances_client: TestClient,
+) -> None:
+    owner_client = _sign_up_and_sign_in(net_balances_client, "owner_multi@example.com")
+    member_client = _sign_up_and_sign_in(net_balances_client, "member_multi@example.com")
+    workspace = _create_shared_workspace(owner_client, member_client)
+
+    owner_id = _get_user_id(owner_client)
+    member_id = _get_user_id(member_client)
+
+    owner_account = _create_account(
+        owner_client,
+        workspace_id=workspace["id"],
+        name="Cuenta owner",
+        account_type="bank_account",
+        currency="ars",
+        initial_balance_minor=100000,
+        description=None,
+    )
+    member_account = _create_account(
+        member_client,
+        workspace_id=workspace["id"],
+        name="Cuenta member",
+        account_type="bank_account",
+        currency="ars",
+        initial_balance_minor=100000,
+        description=None,
+    )
+    expense_category = _find_category_by_name(
+        owner_client,
+        workspace_id=workspace["id"],
+        name="Comida",
+    )
+
+    # Owner pays 10000, equal split -> member owes owner 5000
+    _create_expense(
+        owner_client,
+        workspace_id=workspace["id"],
+        source_account_id=cast(str, owner_account["id"]),
+        category_id=cast(str, expense_category["id"]),
+        paid_by_user_id=owner_id,
+        amount_minor=10000,
+        currency="ars",
+        description="Cena",
+        split_config={
+            "type": "equal",
+            "values": {owner_id: 1, member_id: 1},
+        },
+    )
+
+    # Member pays 6000, equal split -> owner owes member 3000
+    _create_expense(
+        member_client,
+        workspace_id=workspace["id"],
+        source_account_id=cast(str, member_account["id"]),
+        category_id=cast(str, expense_category["id"]),
+        paid_by_user_id=member_id,
+        amount_minor=6000,
+        currency="ars",
+        description="Almuerzo",
+        split_config={
+            "type": "equal",
+            "values": {owner_id: 1, member_id: 1},
+        },
+    )
+
+    # Net: member owes owner 5000 - 3000 = 2000
+    response = owner_client.get(
+        f"/api/v1/workspaces/{workspace['id']}/net-balances",
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["balances"]) == 1
+    entry = data["balances"][0]
+    assert entry["debtor_id"] == member_id
+    assert entry["creditor_id"] == owner_id
+    assert entry["amount_minor"] == 2000
+    assert entry["currency"] == "ARS"
+
+
+def test_transfers_excluded_from_net_balance(
+    net_balances_client: TestClient,
+) -> None:
+    owner_client = _sign_up_and_sign_in(net_balances_client, "owner_transfer@example.com")
+    workspace = _create_workspace(owner_client, name="TransferTest", workspace_type="personal")
+
+    source_account = _create_account(
+        owner_client,
+        workspace_id=workspace["id"],
+        name="Caja",
+        account_type="cash",
+        currency="ARS",
+        initial_balance_minor=20000,
+        description=None,
+    )
+    destination_account = _create_account(
+        owner_client,
+        workspace_id=workspace["id"],
+        name="Banco",
+        account_type="bank_account",
+        currency="ARS",
+        initial_balance_minor=5000,
+        description=None,
+    )
+
+    _create_transfer(
+        owner_client,
+        workspace_id=workspace["id"],
+        source_account_id=cast(str, source_account["id"]),
+        destination_account_id=cast(str, destination_account["id"]),
+        amount_minor=3500,
+        currency="ARS",
+    )
+
+    response = owner_client.get(
+        f"/api/v1/workspaces/{workspace['id']}/net-balances",
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["balances"] == []
+
+
+def test_solo_transactions_excluded_from_net_balance(
+    net_balances_client: TestClient,
+) -> None:
+    owner_client = _sign_up_and_sign_in(net_balances_client, "owner_solo@example.com")
+    workspace = _create_workspace(owner_client, name="SoloTest", workspace_type="personal")
+
+    owner_id = _get_user_id(owner_client)
+
+    account = _create_account(
+        owner_client,
+        workspace_id=workspace["id"],
+        name="Banco",
+        account_type="bank_account",
+        currency="ARS",
+        initial_balance_minor=100000,
+        description=None,
+    )
+    expense_category = _find_category_by_name(
+        owner_client,
+        workspace_id=workspace["id"],
+        name="Comida",
+    )
+
+    _create_expense(
+        owner_client,
+        workspace_id=workspace["id"],
+        source_account_id=cast(str, account["id"]),
+        category_id=cast(str, expense_category["id"]),
+        paid_by_user_id=owner_id,
+        amount_minor=5000,
+        currency="ars",
+        description="Almuerzo personal",
+        split_config=None,
+    )
+
+    response = owner_client.get(
+        f"/api/v1/workspaces/{workspace['id']}/net-balances",
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["balances"] == []
+
+
+def test_multi_currency_produces_separate_balances(
+    net_balances_client: TestClient,
+) -> None:
+    owner_client = _sign_up_and_sign_in(net_balances_client, "owner_currency@example.com")
+    member_client = _sign_up_and_sign_in(net_balances_client, "member_currency@example.com")
+    workspace = _create_shared_workspace(owner_client, member_client)
+
+    owner_id = _get_user_id(owner_client)
+    member_id = _get_user_id(member_client)
+
+    ars_account = _create_account(
+        owner_client,
+        workspace_id=workspace["id"],
+        name="Cuenta ARS",
+        account_type="bank_account",
+        currency="ARS",
+        initial_balance_minor=100000,
+        description=None,
+    )
+    usd_account = _create_account(
+        owner_client,
+        workspace_id=workspace["id"],
+        name="Cuenta USD",
+        account_type="bank_account",
+        currency="USD",
+        initial_balance_minor=100000,
+        description=None,
+    )
+    expense_category = _find_category_by_name(
+        owner_client,
+        workspace_id=workspace["id"],
+        name="Comida",
+    )
+
+    _create_expense(
+        owner_client,
+        workspace_id=workspace["id"],
+        source_account_id=cast(str, ars_account["id"]),
+        category_id=cast(str, expense_category["id"]),
+        paid_by_user_id=owner_id,
+        amount_minor=10000,
+        currency="ars",
+        description="Cena ARS",
+        split_config={
+            "type": "equal",
+            "values": {owner_id: 1, member_id: 1},
+        },
+    )
+
+    _create_expense(
+        owner_client,
+        workspace_id=workspace["id"],
+        source_account_id=cast(str, usd_account["id"]),
+        category_id=cast(str, expense_category["id"]),
+        paid_by_user_id=owner_id,
+        amount_minor=2000,
+        currency="usd",
+        description="Cena USD",
+        split_config={
+            "type": "equal",
+            "values": {owner_id: 1, member_id: 1},
+        },
+    )
+
+    response = owner_client.get(
+        f"/api/v1/workspaces/{workspace['id']}/net-balances",
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["balances"]) == 2
+
+    currencies = {entry["currency"] for entry in data["balances"]}
+    assert currencies == {"ARS", "USD"}
+
+    for entry in data["balances"]:
+        assert entry["debtor_id"] == member_id
+        assert entry["creditor_id"] == owner_id
+        if entry["currency"] == "ARS":
+            assert entry["amount_minor"] == 5000
+        elif entry["currency"] == "USD":
+            assert entry["amount_minor"] == 1000
+
+
+def test_user_id_filter_returns_only_relevant_entries(
+    net_balances_client: TestClient,
+) -> None:
+    owner_client = _sign_up_and_sign_in(net_balances_client, "owner_filter@example.com")
+    member_a_client = _sign_up_and_sign_in(net_balances_client, "member_a@example.com")
+    member_b_client = _sign_up_and_sign_in(net_balances_client, "member_b@example.com")
+
+    workspace = _create_shared_workspace_with_three_members(
+        owner_client,
+        member_a_client,
+        member_b_client,
+    )
+
+    owner_id = _get_user_id(owner_client)
+    member_a_id = _get_user_id(member_a_client)
+    member_b_id = _get_user_id(member_b_client)
+
+    owner_account = _create_account(
+        owner_client,
+        workspace_id=workspace["id"],
+        name="Cuenta owner",
+        account_type="bank_account",
+        currency="ARS",
+        initial_balance_minor=100000,
+        description=None,
+    )
+    member_a_account = _create_account(
+        member_a_client,
+        workspace_id=workspace["id"],
+        name="Cuenta member A",
+        account_type="bank_account",
+        currency="ARS",
+        initial_balance_minor=100000,
+        description=None,
+    )
+    expense_category = _find_category_by_name(
+        owner_client,
+        workspace_id=workspace["id"],
+        name="Comida",
+    )
+
+    # Owner pays 10000, split owner/member_a -> member_a owes owner 5000
+    _create_expense(
+        owner_client,
+        workspace_id=workspace["id"],
+        source_account_id=cast(str, owner_account["id"]),
+        category_id=cast(str, expense_category["id"]),
+        paid_by_user_id=owner_id,
+        amount_minor=10000,
+        currency="ars",
+        description="Cena owner/member_a",
+        split_config={
+            "type": "equal",
+            "values": {owner_id: 1, member_a_id: 1},
+        },
+    )
+
+    # Member A pays 4000, split member_a/member_b -> member_b owes member_a 2000
+    _create_expense(
+        member_a_client,
+        workspace_id=workspace["id"],
+        source_account_id=cast(str, member_a_account["id"]),
+        category_id=cast(str, expense_category["id"]),
+        paid_by_user_id=member_a_id,
+        amount_minor=4000,
+        currency="ars",
+        description="Almuerzo member_a/member_b",
+        split_config={
+            "type": "equal",
+            "values": {member_a_id: 1, member_b_id: 1},
+        },
+    )
+
+    # Filter by member_a: should return both entries (member_a is debtor in one, creditor in other)
+    response = member_a_client.get(
+        f"/api/v1/workspaces/{workspace['id']}/net-balances",
+        params={"user_id": member_a_id},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["balances"]) == 2
+
+    # Filter by owner: should return only the owner/member_a entry
+    response = owner_client.get(
+        f"/api/v1/workspaces/{workspace['id']}/net-balances",
+        params={"user_id": owner_id},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["balances"]) == 1
+    assert data["balances"][0]["debtor_id"] == member_a_id
+    assert data["balances"][0]["creditor_id"] == owner_id
+    assert data["balances"][0]["amount_minor"] == 5000
+
+
+def test_non_member_gets_403(net_balances_client: TestClient) -> None:
+    owner_client = _sign_up_and_sign_in(net_balances_client, "owner_authz@example.com")
+    outsider_client = _sign_up_and_sign_in(net_balances_client, "outsider_authz@example.com")
+    workspace = _create_workspace(owner_client, name="Privado", workspace_type="shared")
+
+    response = outsider_client.get(
+        f"/api/v1/workspaces/{workspace['id']}/net-balances",
+    )
+    assert response.status_code == 403
+    assert response.json() == {"detail": "You do not have access to this workspace."}
+
+
+def test_empty_workspace_returns_empty_list(net_balances_client: TestClient) -> None:
+    owner_client = _sign_up_and_sign_in(net_balances_client, "owner_empty@example.com")
+    workspace = _create_workspace(owner_client, name="Vacio", workspace_type="personal")
+
+    response = owner_client.get(
+        f"/api/v1/workspaces/{workspace['id']}/net-balances",
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["balances"] == []

--- a/backend/tests/test_transactions.py
+++ b/backend/tests/test_transactions.py
@@ -114,7 +114,7 @@ def test_member_can_create_list_get_update_and_delete_income_transaction(
             "currency": "ars",
             "description": "Sueldo marzo",
             "occurred_at": "2026-03-10T12:00:00Z",
-            "split_config": {"kind": "solo"},
+            "split_config": None,
         },
     )
     assert create_response.status_code == 201
@@ -128,7 +128,7 @@ def test_member_can_create_list_get_update_and_delete_income_transaction(
     assert transaction["destination_account"]["id"] == destination_account["id"]
     assert transaction["category"]["name"] == "Salario"
     assert transaction["paid_by_user"]["email"] == "member@example.com"
-    assert transaction["split_config"] == {"kind": "solo"}
+    assert transaction["split_config"] is None
 
     detail_response = member_client.get(
         f"/api/v1/workspaces/{workspace['id']}/transactions/{transaction['id']}"
@@ -642,6 +642,442 @@ def test_receipt_upload_rejects_invalid_media_type_and_size(
     )
     assert oversized_receipt_response.status_code == 413
     assert oversized_receipt_response.json() == {"detail": "Receipt exceeds the 10 MB size limit."}
+
+
+def test_split_config_rejects_invalid_type(transactions_client: TestClient) -> None:
+    owner_client = _sign_up_and_sign_in(transactions_client, "owner@example.com")
+    workspace = _create_workspace(owner_client, name="Gastos", workspace_type="personal")
+    account = _create_account(
+        owner_client,
+        workspace_id=workspace["id"],
+        name="Caja",
+        account_type="cash",
+        currency="ARS",
+        initial_balance_minor=10000,
+        description=None,
+    )
+    category = _find_category_by_name(owner_client, workspace_id=workspace["id"], name="Comida")
+
+    response = owner_client.post(
+        f"/api/v1/workspaces/{workspace['id']}/transactions",
+        json={
+            "type": "expense",
+            "source_account_id": account["id"],
+            "category_id": category["id"],
+            "amount_minor": 5000,
+            "currency": "ARS",
+            "description": "Almuerzo",
+            "occurred_at": "2026-03-10T12:00:00Z",
+            "split_config": {"type": "invalid", "values": {}},
+        },
+    )
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert "split_config.type" in detail or "type" in str(detail)
+
+
+def test_split_config_requires_paid_by_user_id(transactions_client: TestClient) -> None:
+    owner_client = _sign_up_and_sign_in(transactions_client, "owner@example.com")
+    workspace = _create_workspace(owner_client, name="Gastos", workspace_type="personal")
+    account = _create_account(
+        owner_client,
+        workspace_id=workspace["id"],
+        name="Caja",
+        account_type="cash",
+        currency="ARS",
+        initial_balance_minor=10000,
+        description=None,
+    )
+    category = _find_category_by_name(owner_client, workspace_id=workspace["id"], name="Comida")
+
+    response = owner_client.post(
+        f"/api/v1/workspaces/{workspace['id']}/transactions",
+        json={
+            "type": "expense",
+            "source_account_id": account["id"],
+            "category_id": category["id"],
+            "amount_minor": 5000,
+            "currency": "ARS",
+            "description": "Almuerzo",
+            "occurred_at": "2026-03-10T12:00:00Z",
+            "split_config": {"type": "equal"},
+        },
+    )
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert "paid_by_user_id" in detail
+
+
+def test_percentage_split_must_sum_to_100(transactions_client: TestClient) -> None:
+    owner_client = _sign_up_and_sign_in(transactions_client, "owner@example.com")
+    member_client = _sign_up_and_sign_in(transactions_client, "member@example.com")
+    workspace = _create_workspace(owner_client, name="Gastos", workspace_type="shared")
+    invitation = _create_invitation(
+        owner_client,
+        workspace_id=workspace["id"],
+        email="member@example.com",
+    )
+    member_client.post(
+        "/api/v1/workspaces/invitations/accept",
+        json={"token": invitation["invitation_token"]},
+    )
+    account = _create_account(
+        owner_client,
+        workspace_id=workspace["id"],
+        name="Caja",
+        account_type="cash",
+        currency="ARS",
+        initial_balance_minor=10000,
+        description=None,
+    )
+    category = _find_category_by_name(owner_client, workspace_id=workspace["id"], name="Comida")
+    owner_id = owner_client.get("/api/v1/auth/me").json()["user"]["id"]
+    member_id = member_client.get("/api/v1/auth/me").json()["user"]["id"]
+
+    response = owner_client.post(
+        f"/api/v1/workspaces/{workspace['id']}/transactions",
+        json={
+            "type": "expense",
+            "source_account_id": account["id"],
+            "category_id": category["id"],
+            "paid_by_user_id": owner_id,
+            "amount_minor": 10000,
+            "currency": "ARS",
+            "description": "Almuerzo",
+            "occurred_at": "2026-03-10T12:00:00Z",
+            "split_config": {
+                "type": "percentage",
+                "values": {owner_id: 60, member_id: 30},
+            },
+        },
+    )
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert "100" in detail or "sum" in detail.lower()
+
+
+def test_percentage_split_values_must_be_0_to_100(transactions_client: TestClient) -> None:
+    owner_client = _sign_up_and_sign_in(transactions_client, "owner@example.com")
+    member_client = _sign_up_and_sign_in(transactions_client, "member@example.com")
+    workspace = _create_workspace(owner_client, name="Gastos", workspace_type="shared")
+    invitation = _create_invitation(
+        owner_client,
+        workspace_id=workspace["id"],
+        email="member@example.com",
+    )
+    member_client.post(
+        "/api/v1/workspaces/invitations/accept",
+        json={"token": invitation["invitation_token"]},
+    )
+    account = _create_account(
+        owner_client,
+        workspace_id=workspace["id"],
+        name="Caja",
+        account_type="cash",
+        currency="ARS",
+        initial_balance_minor=10000,
+        description=None,
+    )
+    category = _find_category_by_name(owner_client, workspace_id=workspace["id"], name="Comida")
+    owner_id = owner_client.get("/api/v1/auth/me").json()["user"]["id"]
+    member_id = member_client.get("/api/v1/auth/me").json()["user"]["id"]
+
+    response = owner_client.post(
+        f"/api/v1/workspaces/{workspace['id']}/transactions",
+        json={
+            "type": "expense",
+            "source_account_id": account["id"],
+            "category_id": category["id"],
+            "paid_by_user_id": owner_id,
+            "amount_minor": 10000,
+            "currency": "ARS",
+            "description": "Almuerzo",
+            "occurred_at": "2026-03-10T12:00:00Z",
+            "split_config": {
+                "type": "percentage",
+                "values": {owner_id: 50, member_id: 150},
+            },
+        },
+    )
+    assert response.status_code == 422
+
+
+def test_exact_split_must_sum_to_amount(transactions_client: TestClient) -> None:
+    owner_client = _sign_up_and_sign_in(transactions_client, "owner@example.com")
+    member_client = _sign_up_and_sign_in(transactions_client, "member@example.com")
+    workspace = _create_workspace(owner_client, name="Gastos", workspace_type="shared")
+    invitation = _create_invitation(
+        owner_client,
+        workspace_id=workspace["id"],
+        email="member@example.com",
+    )
+    member_client.post(
+        "/api/v1/workspaces/invitations/accept",
+        json={"token": invitation["invitation_token"]},
+    )
+    account = _create_account(
+        owner_client,
+        workspace_id=workspace["id"],
+        name="Caja",
+        account_type="cash",
+        currency="ARS",
+        initial_balance_minor=10000,
+        description=None,
+    )
+    category = _find_category_by_name(owner_client, workspace_id=workspace["id"], name="Comida")
+    owner_id = owner_client.get("/api/v1/auth/me").json()["user"]["id"]
+    member_id = member_client.get("/api/v1/auth/me").json()["user"]["id"]
+
+    response = owner_client.post(
+        f"/api/v1/workspaces/{workspace['id']}/transactions",
+        json={
+            "type": "expense",
+            "source_account_id": account["id"],
+            "category_id": category["id"],
+            "paid_by_user_id": owner_id,
+            "amount_minor": 10000,
+            "currency": "ARS",
+            "description": "Almuerzo",
+            "occurred_at": "2026-03-10T12:00:00Z",
+            "split_config": {
+                "type": "exact",
+                "values": {owner_id: 6000, member_id: 3000},
+            },
+        },
+    )
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert "10000" in detail or "sum" in detail.lower()
+
+
+def test_exact_split_values_must_be_positive(transactions_client: TestClient) -> None:
+    owner_client = _sign_up_and_sign_in(transactions_client, "owner@example.com")
+    member_client = _sign_up_and_sign_in(transactions_client, "member@example.com")
+    workspace = _create_workspace(owner_client, name="Gastos", workspace_type="shared")
+    invitation = _create_invitation(
+        owner_client,
+        workspace_id=workspace["id"],
+        email="member@example.com",
+    )
+    member_client.post(
+        "/api/v1/workspaces/invitations/accept",
+        json={"token": invitation["invitation_token"]},
+    )
+    account = _create_account(
+        owner_client,
+        workspace_id=workspace["id"],
+        name="Caja",
+        account_type="cash",
+        currency="ARS",
+        initial_balance_minor=10000,
+        description=None,
+    )
+    category = _find_category_by_name(owner_client, workspace_id=workspace["id"], name="Comida")
+    owner_id = owner_client.get("/api/v1/auth/me").json()["user"]["id"]
+    member_id = member_client.get("/api/v1/auth/me").json()["user"]["id"]
+
+    response = owner_client.post(
+        f"/api/v1/workspaces/{workspace['id']}/transactions",
+        json={
+            "type": "expense",
+            "source_account_id": account["id"],
+            "category_id": category["id"],
+            "paid_by_user_id": owner_id,
+            "amount_minor": 10000,
+            "currency": "ARS",
+            "description": "Almuerzo",
+            "occurred_at": "2026-03-10T12:00:00Z",
+            "split_config": {
+                "type": "exact",
+                "values": {owner_id: 0, member_id: 10000},
+            },
+        },
+    )
+    assert response.status_code == 422
+
+
+def test_split_config_rejects_non_member_user(transactions_client: TestClient) -> None:
+    owner_client = _sign_up_and_sign_in(transactions_client, "owner@example.com")
+    workspace = _create_workspace(owner_client, name="Gastos", workspace_type="shared")
+    account = _create_account(
+        owner_client,
+        workspace_id=workspace["id"],
+        name="Caja",
+        account_type="cash",
+        currency="ARS",
+        initial_balance_minor=10000,
+        description=None,
+    )
+    category = _find_category_by_name(owner_client, workspace_id=workspace["id"], name="Comida")
+    owner_id = owner_client.get("/api/v1/auth/me").json()["user"]["id"]
+    non_member_id = "00000000-0000-0000-0000-000000000001"
+
+    response = owner_client.post(
+        f"/api/v1/workspaces/{workspace['id']}/transactions",
+        json={
+            "type": "expense",
+            "source_account_id": account["id"],
+            "category_id": category["id"],
+            "paid_by_user_id": owner_id,
+            "amount_minor": 10000,
+            "currency": "ARS",
+            "description": "Almuerzo",
+            "occurred_at": "2026-03-10T12:00:00Z",
+            "split_config": {
+                "type": "percentage",
+                "values": {owner_id: 50, non_member_id: 50},
+            },
+        },
+    )
+    assert response.status_code == 404
+    detail = response.json()["detail"]
+    assert "member" in detail.lower() or "workspace" in detail.lower()
+
+
+def test_valid_equal_split_accepted(transactions_client: TestClient) -> None:
+    owner_client = _sign_up_and_sign_in(transactions_client, "owner@example.com")
+    member_client = _sign_up_and_sign_in(transactions_client, "member@example.com")
+    workspace = _create_workspace(owner_client, name="Gastos", workspace_type="shared")
+    invitation = _create_invitation(
+        owner_client,
+        workspace_id=workspace["id"],
+        email="member@example.com",
+    )
+    member_client.post(
+        "/api/v1/workspaces/invitations/accept",
+        json={"token": invitation["invitation_token"]},
+    )
+    account = _create_account(
+        owner_client,
+        workspace_id=workspace["id"],
+        name="Caja",
+        account_type="cash",
+        currency="ARS",
+        initial_balance_minor=10000,
+        description=None,
+    )
+    category = _find_category_by_name(owner_client, workspace_id=workspace["id"], name="Comida")
+    owner_id = owner_client.get("/api/v1/auth/me").json()["user"]["id"]
+    member_id = member_client.get("/api/v1/auth/me").json()["user"]["id"]
+
+    response = owner_client.post(
+        f"/api/v1/workspaces/{workspace['id']}/transactions",
+        json={
+            "type": "expense",
+            "source_account_id": account["id"],
+            "category_id": category["id"],
+            "paid_by_user_id": owner_id,
+            "amount_minor": 10000,
+            "currency": "ARS",
+            "description": "Almuerzo",
+            "occurred_at": "2026-03-10T12:00:00Z",
+            "split_config": {
+                "type": "equal",
+                "values": {owner_id: 1, member_id: 1},
+            },
+        },
+    )
+    assert response.status_code == 201
+    transaction = response.json()
+    assert transaction["split_config"]["type"] == "equal"
+    assert owner_id in transaction["split_config"]["values"]
+    assert member_id in transaction["split_config"]["values"]
+
+
+def test_valid_percentage_split_accepted(transactions_client: TestClient) -> None:
+    owner_client = _sign_up_and_sign_in(transactions_client, "owner@example.com")
+    member_client = _sign_up_and_sign_in(transactions_client, "member@example.com")
+    workspace = _create_workspace(owner_client, name="Gastos", workspace_type="shared")
+    invitation = _create_invitation(
+        owner_client,
+        workspace_id=workspace["id"],
+        email="member@example.com",
+    )
+    member_client.post(
+        "/api/v1/workspaces/invitations/accept",
+        json={"token": invitation["invitation_token"]},
+    )
+    account = _create_account(
+        owner_client,
+        workspace_id=workspace["id"],
+        name="Caja",
+        account_type="cash",
+        currency="ARS",
+        initial_balance_minor=10000,
+        description=None,
+    )
+    category = _find_category_by_name(owner_client, workspace_id=workspace["id"], name="Comida")
+    owner_id = owner_client.get("/api/v1/auth/me").json()["user"]["id"]
+    member_id = member_client.get("/api/v1/auth/me").json()["user"]["id"]
+
+    response = owner_client.post(
+        f"/api/v1/workspaces/{workspace['id']}/transactions",
+        json={
+            "type": "expense",
+            "source_account_id": account["id"],
+            "category_id": category["id"],
+            "paid_by_user_id": owner_id,
+            "amount_minor": 10000,
+            "currency": "ARS",
+            "description": "Almuerzo",
+            "occurred_at": "2026-03-10T12:00:00Z",
+            "split_config": {
+                "type": "percentage",
+                "values": {owner_id: 60, member_id: 40},
+            },
+        },
+    )
+    assert response.status_code == 201
+    transaction = response.json()
+    assert transaction["split_config"]["type"] == "percentage"
+
+
+def test_valid_exact_split_accepted(transactions_client: TestClient) -> None:
+    owner_client = _sign_up_and_sign_in(transactions_client, "owner@example.com")
+    member_client = _sign_up_and_sign_in(transactions_client, "member@example.com")
+    workspace = _create_workspace(owner_client, name="Gastos", workspace_type="shared")
+    invitation = _create_invitation(
+        owner_client,
+        workspace_id=workspace["id"],
+        email="member@example.com",
+    )
+    member_client.post(
+        "/api/v1/workspaces/invitations/accept",
+        json={"token": invitation["invitation_token"]},
+    )
+    account = _create_account(
+        owner_client,
+        workspace_id=workspace["id"],
+        name="Caja",
+        account_type="cash",
+        currency="ARS",
+        initial_balance_minor=10000,
+        description=None,
+    )
+    category = _find_category_by_name(owner_client, workspace_id=workspace["id"], name="Comida")
+    owner_id = owner_client.get("/api/v1/auth/me").json()["user"]["id"]
+    member_id = member_client.get("/api/v1/auth/me").json()["user"]["id"]
+
+    response = owner_client.post(
+        f"/api/v1/workspaces/{workspace['id']}/transactions",
+        json={
+            "type": "expense",
+            "source_account_id": account["id"],
+            "category_id": category["id"],
+            "paid_by_user_id": owner_id,
+            "amount_minor": 10000,
+            "currency": "ARS",
+            "description": "Almuerzo",
+            "occurred_at": "2026-03-10T12:00:00Z",
+            "split_config": {
+                "type": "exact",
+                "values": {owner_id: 6000, member_id: 4000},
+            },
+        },
+    )
+    assert response.status_code == 201
+    transaction = response.json()
+    assert transaction["split_config"]["type"] == "exact"
 
 
 def _sign_up_and_sign_in(client: TestClient, email: str) -> TestClient:

--- a/docs/adr/0006-computed-net-balance-strategy.md
+++ b/docs/adr/0006-computed-net-balance-strategy.md
@@ -1,0 +1,62 @@
+# ADR 0006: Computed net balance strategy
+
+- Status: accepted
+- Date: 2026-03-22
+
+## Context
+
+Shared workspaces need a net balance view that shows how much each member owes or is owed after shared expenses are split. This value drives settlement prompts, dashboards, and the core value proposition of shared-finance features.
+
+Several storage strategies exist for derived values like net balance. The choice affects read performance, write complexity, data freshness, and how well the approach aligns with the patterns already established in ADR 0005.
+
+Key constraints for MVP:
+
+- the split configuration for each transaction is stored in a `split_config` JSON field on the transaction record, capturing the split type and participant shares
+- net balances are per-currency; cross-currency netting is out of scope for MVP
+- transfers must be excluded from net balance computation, consistent with their exclusion from income and expense analytics
+- the system should remain simple enough for couple-scale workloads without premature infrastructure
+
+## Decision
+
+Compute net balances from transaction history on each read using database queries.
+
+- no materialized views, persistent summary tables, or background jobs are used for net balance
+- the query joins workspace transactions with their `split_config` data to derive per-member shares and aggregate the net position
+- the result is a real-time calculation with no staleness window
+- this mirrors the "recompute from history" pattern already used for `current_balance_minor` in ADR 0005
+
+## Rationale
+
+- **Simplicity.** Computed queries avoid the need for refresh pipelines, trigger chains, or cache invalidation logic. The read path is the only path that needs to be correct.
+- **Correctness.** Recomputing from the canonical transaction history guarantees the net balance always reflects the current state of the ledger, including recent creates, updates, and deletes.
+- **Consistency.** This approach aligns directly with ADR 0005's decision to recompute account balances from history rather than maintain incremental deltas. Applying the same principle to net balance keeps the system's mental model uniform.
+- **Low coupling.** No extra tables or materialized views means fewer schema objects to migrate, index, and keep in sync as the domain model evolves.
+
+## Consequences
+
+### Positive
+
+- net balance is always current with no staleness window
+- no refresh infrastructure, background jobs, or cron schedules to maintain
+- schema changes to transactions or split_config do not require migrating a separate summary table
+- the approach scales naturally as the query logic evolves during early product iteration
+
+### Trade-offs
+
+- every net-balance read pays a CPU and I/O cost proportional to the workspace's transaction history
+- aggregate queries may become a bottleneck at very high transaction volumes, but couple-scale workloads are well within acceptable performance for MVP
+- caching at the application or HTTP layer can be added later without changing the underlying query strategy
+
+## Alternatives considered
+
+### Materialized view
+
+Rejected because it introduces a refresh strategy (manual, scheduled, or incremental) that adds operational complexity without a clear performance need at MVP scale. Stale-data edge cases during refresh windows also complicate correctness guarantees.
+
+### Persistent table with triggers
+
+Rejected because it moves logic into database triggers, making the write path harder to test, debug, and version alongside application code. Trigger ordering and error handling become a maintenance burden.
+
+### Application-level caching
+
+Rejected for MVP because it adds cache invalidation logic before the performance need is demonstrated. The read-path cost of computed queries is acceptable at couple-scale transaction volumes and can be revisited if profiling shows a real bottleneck.

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -115,6 +115,8 @@ For shared-expense support, transactions should be able to store:
 - transfers must not count as standard income or expense in analytics
 - each transaction can link to at most one stored receipt object
 - money values are stored in integer minor units
+- net balances are derived from split-configured expense transactions, not stored separately
+- transfers are excluded from net balance computation
 
 ## Initial ER diagram
 
@@ -250,4 +252,35 @@ Those additions should be layered onto the core model rather than forcing a rede
 - receipt upload is allowed for income, expense, and transfer transactions
 - receipt binaries live in S3-compatible object storage and are streamed back through backend routes
 - `split_config` is nullable JSON reserved for shared-expense flows
+- `split_config` structure when present:
+  ```json
+  {
+    "type": "equal" | "percentage" | "exact",
+    "values": {"<user-uuid>": <int>, ...}
+  }
+  ```
+  - `equal`: values dict is optional; participants split the amount equally
+  - `percentage`: each value is 0–100, all must sum to 100
+  - `exact`: each value is >0, all must sum to `amount_minor`
+  - `paid_by_user_id` must be present when `split_config` is set
+  - all user UUIDs in values must reference workspace members
 - account `current_balance_minor` is recomputed from transaction history after every transaction create, update, and hard delete
+
+## Net balance computation
+
+Net balances are derived from transaction history, not stored as a separate table.
+
+Computation rules:
+
+- only expense transactions with `split_config` and `paid_by_user_id` contribute to net balances
+- each participant in `split_config.values` owes the payer their computed share
+- bilateral debts are netted: if A owes B 5000 and B owes A 3000, the net result is A owes B 2000
+- transfers are excluded from net balance computation
+- net balances are per-currency; no cross-currency netting is performed
+- the net balance endpoint accepts an optional `user_id` filter to return only entries involving a specific user
+
+Share computation by split type:
+
+- **equal**: amount divided equally among all participants in values, with remainder distributed to first participants
+- **percentage**: `amount_minor * percentage / 100` for each participant
+- **exact**: the value assigned to each participant is used directly


### PR DESCRIPTION
## Summary

- Implements split logic infrastructure: `paid_by_user_id`, `split_config` JSONB on transactions, and net balance computation
- Adds net balance API endpoint and user-scoped transaction filtering
- Seeds default shared workspace for existing users
- Documents architectural decisions in ADR 0006

## Changes

- **Net balance computation**: Pairwise net balance calculation from transaction history supporting equal, percentage, and exact split types (`backend/src/app/repositories/net_balances.py`)
- **Split config validation**: Thorough validation for split types including membership checks, value summing, and payer participation (`backend/src/app/services/transactions.py`)
- **API routes**: `GET /workspaces/{id}/net-balances` endpoint and `GET /workspaces/{id}/transactions?user_id=...` filtering
- **Seed migration**: Creates default "Gastos compartidos" shared workspace with owner membership and default categories for existing users
- **Tests**: 11 net balance tests + transaction tests covering all split types, edge cases, transfers exclusion, multi-currency, and authorization
- **Documentation**: ADR 0006 (computed net balance strategy) and data model updates

## Architecture Decision

Per ADR 0006, net balances are computed on-read from transaction history rather than stored in a persistent Ledger/Debt table. This is functionally equivalent and simpler for MVP scale.

## Closes

Closes #5