### PR TITLE
fix: run uvicorn directly instead of uv run at runtime

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,4 +17,4 @@ RUN uv sync --frozen --no-dev
 
 EXPOSE 8000
 
-CMD ["uv", "run", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["/app/.venv/bin/uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- Run uvicorn binary directly instead of `uv run` at container startup
- Avoids unnecessary dependency checking on every container boot
- Dependencies remain frozen at build time via `uv sync --frozen --no-dev`

## Testing
- [ ] `docker compose build backend` completes successfully
- [ ] `docker compose up backend` starts without errors
- [ ] API responds at expected port