### PR TITLE
ci: harden Docker build pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: backend/uv.lock
 
       - name: Install backend dependencies
         run: uv sync --project backend

--- a/.github/workflows/docker-preview.yml
+++ b/.github/workflows/docker-preview.yml
@@ -14,39 +14,8 @@ env:
   BACKEND_IMAGE_NAME: creep1ng/shared-expenses-tracking-backend
 
 jobs:
-  metadata:
-    runs-on: ubuntu-latest
-    outputs:
-      frontend-image: ${{ steps.frontend_meta.outputs.tags }}
-      backend-image: ${{ steps.backend_meta.outputs.tags }}
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Extract frontend metadata
-        id: frontend_meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=sha
-
-      - name: Extract backend metadata
-        id: backend_meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=sha
-
   publish-preview:
     runs-on: ubuntu-latest
-    needs: metadata
     permissions:
       contents: read
       packages: write
@@ -108,6 +77,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.component }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.component }}
 
       - name: Build image without push for forks or missing scaffold
         if: steps.scaffold.outputs.present == 'true' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
@@ -118,6 +89,8 @@ jobs:
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.component }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.component }}
 
       - name: Report skipped component
         if: steps.scaffold.outputs.present != 'true'

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,12 @@
+.venv
+__pycache__
+.pytest_cache
+.mypy_cache
+.ruff_cache
+.coverage
+htmlcov
+.git
+.env*
+dist
+build
+*.egg-info

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,6 @@
-FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+# syntax=docker/dockerfile:1.7
+
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim AS builder
 
 WORKDIR /app
 
@@ -7,14 +9,35 @@ ENV UV_LINK_MODE=copy \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
-COPY pyproject.toml README.md ./
+COPY pyproject.toml uv.lock README.md ./
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-install-project
+
 COPY src ./src
 COPY alembic.ini ./alembic.ini
 COPY alembic ./alembic
-COPY uv.lock ./
 
-RUN uv sync --frozen --no-dev
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev
+
+FROM python:3.13-slim AS runtime
+
+WORKDIR /app
+
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN groupadd --system app && useradd --system --gid app --home-dir /app app
+
+COPY --from=builder --chown=app:app /app /app
+
+USER app
 
 EXPOSE 8000
 
-CMD ["/app/.venv/bin/uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/api/v1/health', timeout=5).read()"
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,10 @@ services:
   proxy:
     image: nginx:1.27-alpine
     depends_on:
-      - frontend
-      - backend
+      frontend:
+        condition: service_healthy
+      backend:
+        condition: service_healthy
     ports:
       - "${PROXY_HTTP_PORT:-8080}:80"
     volumes:
@@ -17,13 +19,25 @@ services:
       dockerfile: Dockerfile
     image: ${FRONTEND_IMAGE:-shared-expenses-tracking-frontend:local}
     environment:
-      NODE_ENV: ${FRONTEND_NODE_ENV:-development}
+      NODE_ENV: ${FRONTEND_NODE_ENV:-production}
       PORT: 3000
       NEXT_PUBLIC_API_BASE_PATH: ${NEXT_PUBLIC_API_BASE_PATH:-/api}
       NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-}
       INTERNAL_API_URL: ${INTERNAL_API_URL:-http://backend:8000}
     expose:
       - "3000"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "const http=require('http'); const req=http.get('http://127.0.0.1:3000/', (res) => process.exit(res.statusCode < 500 ? 0 : 1)); req.on('error', () => process.exit(1)); req.setTimeout(5000, () => { req.destroy(); process.exit(1); });",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     networks:
       - app
 
@@ -61,10 +75,20 @@ services:
         condition: service_started
       minio:
         condition: service_started
-    ports:
-      - "${BACKEND_PORT:-8000}:8000"
     expose:
       - "8000"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/api/v1/health', timeout=5).read()",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     networks:
       - app
 
@@ -74,8 +98,6 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-shared_expenses}
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
-    ports:
-      - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
@@ -88,8 +110,6 @@ services:
 
   redis:
     image: redis:7-alpine
-    ports:
-      - "${REDIS_PORT:-6379}:6379"
     volumes:
       - redis_data:/data
     networks:
@@ -101,9 +121,6 @@ services:
     environment:
       MINIO_ROOT_USER: ${S3_ACCESS_KEY_ID:-minioadmin}
       MINIO_ROOT_PASSWORD: ${S3_SECRET_ACCESS_KEY:-minioadmin}
-    ports:
-      - "${MINIO_API_PORT:-9000}:9000"
-      - "${MINIO_CONSOLE_PORT:-9001}:9001"
     volumes:
       - minio_data:/data
     networks:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -3,3 +3,11 @@ node_modules
 .git
 .env*
 *.md
+coverage
+playwright-report
+test-results
+.turbo
+npm-debug.log*
+pnpm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,18 +1,45 @@
+# syntax=docker/dockerfile:1.7
+
 FROM node:22-alpine AS base
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
+ENV NEXT_TELEMETRY_DISABLED=1
 
 RUN corepack enable
 
 WORKDIR /app
 
-COPY package.json ./
+FROM base AS deps
 
-RUN pnpm install
+COPY package.json pnpm-lock.yaml ./
+
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --frozen-lockfile
+
+FROM deps AS builder
 
 COPY . .
 
+RUN pnpm build
+
+FROM node:22-alpine AS runner
+
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1 \
+    HOSTNAME=0.0.0.0 \
+    PORT=3000
+
+WORKDIR /app
+
+COPY --from=builder --chown=node:node /app/.next/standalone ./
+COPY --from=builder --chown=node:node /app/.next/static ./.next/static
+
+USER node
+
 EXPOSE 3000
 
-CMD ["pnpm", "dev"]
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD node -e "const http=require('http'); const req=http.get('http://127.0.0.1:3000/', (res) => process.exit(res.statusCode < 500 ? 0 : 1)); req.on('error', () => process.exit(1)); req.setTimeout(5000, () => { req.destroy(); process.exit(1); });"
+
+CMD ["node", "server.js"]

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  output: "standalone",
   experimental: {
     typedRoutes: true,
   },

--- a/frontend/src/components/accounts/accounts-panel.test.tsx
+++ b/frontend/src/components/accounts/accounts-panel.test.tsx
@@ -112,6 +112,8 @@ describe("AccountsPanel", () => {
 
     await screen.findByText("Cuenta principal");
 
+    await user.click(screen.getByRole("button", { name: /nueva cuenta/i }));
+
     await user.clear(screen.getByLabelText(/^Nombre$/i));
     await user.type(screen.getByLabelText(/^Nombre$/i), "Tarjeta viaje");
     await user.selectOptions(screen.getByLabelText(/^Tipo$/i), "credit_card");

--- a/frontend/src/components/categories/categories-panel.test.tsx
+++ b/frontend/src/components/categories/categories-panel.test.tsx
@@ -115,6 +115,8 @@ describe("CategoriesPanel", () => {
 
     await screen.findByText("Comida");
 
+    await user.click(screen.getByRole("button", { name: /nueva categoría/i }));
+
     await user.clear(screen.getByLabelText(/^Nombre$/i));
     await user.type(screen.getByLabelText(/^Nombre$/i), "Mascotas");
     await user.clear(screen.getByLabelText(/^Icono$/i));
@@ -150,7 +152,7 @@ describe("CategoriesPanel", () => {
     await user.type(editIconInput, "shopping-basket");
     await user.clear(editColorInput);
     await user.type(editColorInput, "#2563eb");
-    await user.click(screen.getByRole("button", { name: /guardar cambios/i }));
+    await user.click(screen.getByRole("button", { name: /guardar/i }));
 
     await waitFor(() => {
       expect(updateCategoryMock).toHaveBeenCalledWith("workspace-1", "cat-1", {

--- a/frontend/src/components/transactions/transactions-panel.test.tsx
+++ b/frontend/src/components/transactions/transactions-panel.test.tsx
@@ -272,6 +272,8 @@ describe("TransactionsPanel", () => {
 
     await screen.findByText("Traspaso ahorro");
 
+    await user.click(screen.getByRole("button", { name: /nuevo movimiento/i }));
+
     await user.clear(screen.getByLabelText(/^Importe$/i));
     await user.type(screen.getByLabelText(/^Importe$/i), "12.50");
     await user.selectOptions(screen.getByLabelText(/^Cuenta de origen$/i), "acc-1");
@@ -415,6 +417,8 @@ describe("TransactionsPanel", () => {
     render(<TransactionsPanel workspaceId="workspace-1" onTransactionsChanged={onTransactionsChanged} />);
 
     await screen.findByText("Traspaso ahorro");
+
+    await user.click(screen.getByRole("button", { name: /nuevo movimiento/i }));
 
     await user.selectOptions(screen.getByLabelText(/tipo de movimiento/i), "transfer");
 

--- a/frontend/src/components/ui/modal.tsx
+++ b/frontend/src/components/ui/modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect } from "react";
+import React, { useEffect, useId } from "react";
 import { X } from "lucide-react";
 
 type ModalProps = {
@@ -12,6 +12,9 @@ type ModalProps = {
 };
 
 export function Modal({ isOpen, onClose, title, description, children }: ModalProps) {
+  const titleId = useId();
+  const descriptionId = useId();
+
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
@@ -30,11 +33,18 @@ export function Modal({ isOpen, onClose, title, description, children }: ModalPr
 
   return (
     <div className="modal-backdrop" onClick={onClose}>
-      <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+      <div
+        aria-describedby={description ? descriptionId : undefined}
+        aria-labelledby={titleId}
+        aria-modal="true"
+        className="modal-content"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+      >
         <div className="modal-header">
           <div>
-            <h2 className="workspace-section-title" style={{ margin: 0 }}>{title}</h2>
-            {description && <p className="workspace-section-copy" style={{ marginTop: "0.25rem" }}>{description}</p>}
+            <h2 className="workspace-section-title" id={titleId} style={{ margin: 0 }}>{title}</h2>
+            {description && <p className="workspace-section-copy" id={descriptionId} style={{ marginTop: "0.25rem" }}>{description}</p>}
           </div>
           <button className="modal-close" onClick={onClose} aria-label="Cerrar modal">
             <X size={20} />

--- a/frontend/src/components/workspaces/workspace-create-page.tsx
+++ b/frontend/src/components/workspaces/workspace-create-page.tsx
@@ -6,6 +6,7 @@ import { ArrowLeft, UserPlus, X } from "lucide-react";
 
 import { WorkspaceCreateForm } from "@/components/workspaces/workspace-create-form";
 import { createWorkspace, createWorkspaceInvitation } from "@/lib/workspaces/api";
+import type { Workspace } from "@/lib/workspaces/types";
 import { getErrorMessage } from "@/lib/auth/errors";
 
 type Notice = {
@@ -16,7 +17,7 @@ type Notice = {
 export function WorkspaceCreatePage() {
   const router = useRouter();
   const [notice, setNotice] = useState<Notice | null>(null);
-  const [createdWorkspace, setCreatedWorkspace] = useState<any>(null);
+  const [createdWorkspace, setCreatedWorkspace] = useState<Workspace | null>(null);
   const [emailsToInvite, setEmailsToInvite] = useState<string[]>([]);
   const [currentEmail, setCurrentEmail] = useState("");
   const [isInviting, setIsInviting] = useState(false);
@@ -48,10 +49,14 @@ export function WorkspaceCreatePage() {
   };
 
   const handleSkip = () => {
+    if (!createdWorkspace) return;
+
     router.push(`/?workspace=${createdWorkspace.id}`);
   };
 
   const handleInviteMembers = async () => {
+    if (!createdWorkspace) return;
+
     setIsInviting(true);
     try {
       if (emailsToInvite.length > 0) {

--- a/frontend/src/components/workspaces/workspace-dashboard.test.tsx
+++ b/frontend/src/components/workspaces/workspace-dashboard.test.tsx
@@ -166,7 +166,11 @@ describe("WorkspaceDashboard", () => {
     expect(screen.getByText("ana@example.com")).toBeInTheDocument();
     expect(screen.getByText("KPIs workspace-1 refresco 0")).toBeInTheDocument();
     expect(screen.getByText("Panel cuentas workspace-1 refresco 0")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /categorías/i }));
     expect(screen.getByText("Panel categorias workspace-1")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /movimientos/i }));
     expect(screen.getByText("Panel movimientos workspace-1")).toBeInTheDocument();
   });
 


### PR DESCRIPTION
Closes #67

## Summary
- Converts backend and frontend images to production-oriented multi-stage builds with non-root runtimes and healthchecks.
- Adds Docker/uv/pnpm cache improvements across Dockerfiles and GitHub Actions.
- Tightens Compose defaults so only the proxy is published and updates frontend tests for the modal-based UI.

## Changes
| File | Change |
|------|--------|
| `backend/Dockerfile` | Adds builder/runtime split, uv cache mounts, non-root runtime, and healthcheck. |
| `backend/.dockerignore` | Excludes local caches, virtualenvs, env files, and build outputs from Docker context. |
| `frontend/Dockerfile` | Adds pnpm lockfile install, production `next build`, standalone runtime, non-root user, and healthcheck. |
| `frontend/next.config.ts` | Enables Next.js standalone output for smaller runtime image. |
| `docker-compose.yml` | Adds service healthchecks, proxy health dependencies, production frontend env, and removes host publishing for internal services. |
| `.github/workflows/ci.yml` | Enables uv dependency caching. |
| `.github/workflows/docker-preview.yml` | Removes unused metadata job and enables GitHub Actions Docker layer cache. |
| `frontend/src/components/ui/modal.tsx` | Adds dialog ARIA semantics used by the current modal UI. |
| `frontend/src/components/**/*.test.tsx` | Updates tests to interact with modal-based UI and tabbed dashboard behavior. |

## Test Plan
- [x] `docker compose config`
- [x] `docker build -t shared-expenses-tracking-backend:test ./backend`
- [x] `docker build -t shared-expenses-tracking-frontend:test ./frontend`
- [x] `docker compose up --build -d`
- [x] `docker compose ps` shows backend/frontend healthy
- [x] `curl -fsS http://127.0.0.1:8080/api/v1/health`
- [x] `curl -fsSI http://127.0.0.1:8080/`
- [x] `make lint`
- [x] `make typecheck`
- [x] `make test`

## Notes
- Current final image sizes observed locally: backend `235MB`, frontend `227MB`.
- Existing local images before this change were observed as backend `384MB` and frontend `1.58GB`.