### PR TITLE
feat(frontend): add category icon picker

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -165,6 +165,18 @@ textarea {
   gap: 0.4rem;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .auth-label,
 .dashboard-stat-label {
   font-size: 0.9rem;
@@ -678,6 +690,70 @@ textarea {
   font-size: 1.35rem;
   font-weight: 700;
   box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.12);
+}
+
+.category-icon-picker {
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+}
+
+.category-icon-search {
+  display: block;
+}
+
+.category-icon-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));
+  max-height: 16rem;
+  gap: 0.55rem;
+  overflow-y: auto;
+  padding: 0.25rem;
+  border-radius: 18px;
+}
+
+.category-icon-grid[aria-invalid="true"] {
+  box-shadow: 0 0 0 4px rgba(171, 60, 47, 0.09);
+}
+
+.category-icon-option {
+  display: grid;
+  gap: 0.35rem;
+  justify-items: center;
+  min-height: 5.25rem;
+  padding: 0.7rem 0.55rem;
+  border: 1px solid rgba(90, 60, 130, 0.14);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--foreground);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-align: center;
+  transition: border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
+}
+
+.category-icon-option:hover,
+.category-icon-option:focus-visible {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px rgba(150, 103, 224, 0.12);
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.category-icon-option-selected {
+  border-color: var(--accent);
+  background: rgba(150, 103, 224, 0.14);
+  color: var(--accent-strong);
+}
+
+.category-icon-empty {
+  margin: 0;
+  padding: 0.75rem;
+  color: var(--muted);
+  font-size: 0.9rem;
 }
 
 .transaction-card {

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -692,6 +692,16 @@ textarea {
   box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.12);
 }
 
+.category-form-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 13rem), 1fr));
+}
+
+.category-picker-field {
+  grid-column: 1 / -1;
+}
+
 .category-icon-picker {
   min-width: 0;
   padding: 0;
@@ -705,12 +715,13 @@ textarea {
 
 .category-icon-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));
-  max-height: 16rem;
+  grid-template-columns: repeat(auto-fill, minmax(5.75rem, 1fr));
+  max-height: min(14rem, 42vh);
   gap: 0.55rem;
   overflow-y: auto;
   padding: 0.25rem;
   border-radius: 18px;
+  scrollbar-gutter: stable;
 }
 
 .category-icon-grid[aria-invalid="true"] {
@@ -721,8 +732,9 @@ textarea {
   display: grid;
   gap: 0.35rem;
   justify-items: center;
-  min-height: 5.25rem;
-  padding: 0.7rem 0.55rem;
+  min-width: 0;
+  min-height: 4.75rem;
+  padding: 0.65rem 0.45rem;
   border: 1px solid rgba(90, 60, 130, 0.14);
   border-radius: 18px;
   background: rgba(255, 255, 255, 0.72);
@@ -733,6 +745,13 @@ textarea {
   font-weight: 700;
   text-align: center;
   transition: border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
+}
+
+.category-icon-option span {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .category-icon-option:hover,
@@ -754,6 +773,93 @@ textarea {
   padding: 0.75rem;
   color: var(--muted);
   font-size: 0.9rem;
+}
+
+.category-color-picker {
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+}
+
+.category-color-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(2.5rem, 1fr));
+  gap: 0.55rem;
+  padding: 0.25rem;
+  border-radius: 18px;
+}
+
+.category-color-grid[aria-invalid="true"] {
+  box-shadow: 0 0 0 4px rgba(171, 60, 47, 0.09);
+}
+
+.category-color-option {
+  position: relative;
+  display: inline-grid;
+  min-width: 0;
+  width: 100%;
+  aspect-ratio: 1;
+  place-items: center;
+  padding: 0.3rem;
+  border: 1px solid rgba(90, 60, 130, 0.14);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.72);
+  cursor: pointer;
+  transition: border-color 180ms ease, outline-color 180ms ease, transform 180ms ease;
+}
+
+.category-color-option span {
+  width: 100%;
+  height: 100%;
+  border: 1px solid rgba(26, 21, 37, 0.18);
+  border-radius: 11px;
+}
+
+.category-color-option:hover,
+.category-color-option:focus-visible {
+  border-color: var(--accent);
+  outline: 3px solid rgba(150, 103, 224, 0.34);
+  outline-offset: 2px;
+  transform: translateY(-1px);
+}
+
+.category-color-option-selected {
+  border-color: var(--accent);
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.category-color-option-selected::after {
+  position: absolute;
+  right: 0.18rem;
+  bottom: 0.18rem;
+  width: 0.7rem;
+  height: 0.7rem;
+  border: 2px solid #ffffff;
+  border-radius: 999px;
+  background: var(--foreground);
+  content: "";
+}
+
+@media (max-width: 480px), (max-height: 520px) and (orientation: landscape) {
+  .category-icon-grid {
+    grid-template-columns: repeat(auto-fill, minmax(4.9rem, 1fr));
+    max-height: 10.5rem;
+  }
+
+  .category-icon-option {
+    min-height: 4.25rem;
+    font-size: 0.74rem;
+  }
+
+  .category-color-grid {
+    grid-template-columns: repeat(auto-fill, minmax(2.1rem, 1fr));
+  }
+
+  .category-color-option {
+    border-radius: 14px;
+  }
 }
 
 .transaction-card {

--- a/frontend/src/components/categories/categories-panel.test.tsx
+++ b/frontend/src/components/categories/categories-panel.test.tsx
@@ -123,8 +123,7 @@ describe("CategoriesPanel", () => {
     await user.type(screen.getByLabelText(/^Nombre$/i), "Mascotas");
     await user.type(screen.getByLabelText(/^Buscar ícono$/i), "mascotas");
     await user.click(screen.getByRole("radio", { name: "Mascotas" }));
-    await user.clear(screen.getByLabelText(/^Color$/i));
-    await user.type(screen.getByLabelText(/^Color$/i), "#7c3aed");
+    await user.click(screen.getByRole("radio", { name: "Color #7C3AED" }));
     await user.click(screen.getByRole("button", { name: /crear categoría/i }));
 
     await waitFor(() => {
@@ -146,14 +145,12 @@ describe("CategoriesPanel", () => {
 
     const editNameInput = screen.getByLabelText("Nombre", { selector: "input[id='category-edit-cat-1-name']" });
     const editIconSearchInput = screen.getByLabelText("Buscar ícono", { selector: "input[id='category-edit-cat-1-icon-search']" });
-    const editColorInput = screen.getByLabelText("Color", { selector: "input[id='category-edit-cat-1-color']" });
 
     await user.clear(editNameInput);
     await user.type(editNameInput, "Supermercado");
     await user.type(editIconSearchInput, "supermercado");
     await user.click(screen.getByRole("radio", { name: "Supermercado" }));
-    await user.clear(editColorInput);
-    await user.type(editColorInput, "#2563eb");
+    await user.click(screen.getByRole("radio", { name: "Color #2563EB" }));
     await user.click(screen.getByRole("button", { name: /guardar/i }));
 
     await waitFor(() => {

--- a/frontend/src/components/categories/categories-panel.test.tsx
+++ b/frontend/src/components/categories/categories-panel.test.tsx
@@ -62,6 +62,7 @@ describe("CategoriesPanel", () => {
 
     expect(await screen.findByText("Comida")).toBeInTheDocument();
     expect(screen.queryByText("Archivada")).not.toBeInTheDocument();
+    expect(screen.queryByText("utensils-crossed")).not.toBeInTheDocument();
     expect(listCategoriesMock).toHaveBeenCalledWith("workspace-1");
   });
 
@@ -120,8 +121,8 @@ describe("CategoriesPanel", () => {
 
     await user.clear(screen.getByLabelText(/^Nombre$/i));
     await user.type(screen.getByLabelText(/^Nombre$/i), "Mascotas");
-    await user.clear(screen.getByLabelText(/^Ícono$/i));
-    await user.type(screen.getByLabelText(/^Ícono$/i), "paw-print");
+    await user.type(screen.getByLabelText(/^Buscar ícono$/i), "mascotas");
+    await user.click(screen.getByRole("radio", { name: "Mascotas" }));
     await user.clear(screen.getByLabelText(/^Color$/i));
     await user.type(screen.getByLabelText(/^Color$/i), "#7c3aed");
     await user.click(screen.getByRole("button", { name: /crear categoría/i }));
@@ -144,13 +145,13 @@ describe("CategoriesPanel", () => {
     await user.click(within(originalCategoryCard as HTMLElement).getByRole("button", { name: /editar/i }));
 
     const editNameInput = screen.getByLabelText("Nombre", { selector: "input[id='category-edit-cat-1-name']" });
-    const editIconInput = screen.getByLabelText("Ícono", { selector: "input[id='category-edit-cat-1-icon']" });
+    const editIconSearchInput = screen.getByLabelText("Buscar ícono", { selector: "input[id='category-edit-cat-1-icon-search']" });
     const editColorInput = screen.getByLabelText("Color", { selector: "input[id='category-edit-cat-1-color']" });
 
     await user.clear(editNameInput);
     await user.type(editNameInput, "Supermercado");
-    await user.clear(editIconInput);
-    await user.type(editIconInput, "shopping-basket");
+    await user.type(editIconSearchInput, "supermercado");
+    await user.click(screen.getByRole("radio", { name: "Supermercado" }));
     await user.clear(editColorInput);
     await user.type(editColorInput, "#2563eb");
     await user.click(screen.getByRole("button", { name: /guardar/i }));

--- a/frontend/src/components/categories/categories-panel.tsx
+++ b/frontend/src/components/categories/categories-panel.tsx
@@ -10,6 +10,7 @@ import {
   DEFAULT_CATEGORY_FORM_VALUES,
 } from "@/components/categories/category-form";
 import { getErrorMessage } from "@/lib/auth/errors";
+import { CategoryIcon } from "@/lib/categories/icons";
 import {
   archiveCategory,
   createCategory,
@@ -36,18 +37,6 @@ function toCategoryFormDefaults(category: Category) {
     icon: category.icon,
     color: category.color,
   } as const;
-}
-
-function getVisibleCategoryIcon(icon: string): string | null {
-  const trimmedIcon = icon.trim();
-
-  if (!trimmedIcon) {
-    return null;
-  }
-
-  return Array.from(trimmedIcon).some((character) => character.length > 1 && !/[\w-]/.test(character))
-    ? trimmedIcon
-    : null;
 }
 
 export function CategoriesPanel({ workspaceId, mode = "crud" }: CategoriesPanelProps) {
@@ -178,8 +167,6 @@ export function CategoriesPanel({ workspaceId, mode = "crud" }: CategoriesPanelP
         {!isLoading
           ? categories.map((category) => {
               const isEditing = editingCategoryId === category.id;
-              const visibleIcon = getVisibleCategoryIcon(category.icon);
-
               return (
                 <article key={category.id} className="kpi-card" style={{ borderTop: `4px solid ${category.color}`, padding: "1.5rem" }}>
                   <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: "1rem" }}>
@@ -187,9 +174,9 @@ export function CategoriesPanel({ workspaceId, mode = "crud" }: CategoriesPanelP
                       <span
                         aria-hidden="true"
                         className="category-marker"
-                        style={{ backgroundColor: visibleIcon ? undefined : category.color }}
+                        style={{ backgroundColor: category.color }}
                       >
-                        {visibleIcon}
+                        <CategoryIcon icon={category.icon} />
                       </span>
                       <h3 className="kpi-label" style={{ fontSize: "1.1rem", margin: 0, color: "var(--foreground)" }}>{category.name}</h3>
                     </div>

--- a/frontend/src/components/categories/category-form.tsx
+++ b/frontend/src/components/categories/category-form.tsx
@@ -6,6 +6,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 
 import { CATEGORY_TYPE_OPTIONS } from "@/lib/categories/presentation";
+import { CategoryIcon, CATEGORY_ICON_OPTIONS } from "@/lib/categories/icons";
 import { categoryFormSchema, type CategoryFormValues } from "@/lib/categories/schemas";
 import type { CategoryCreatePayload } from "@/lib/categories/types";
 
@@ -36,9 +37,24 @@ export function CategoryForm({
   fieldIdPrefix,
 }: CategoryFormProps) {
   const [isPending, startTransition] = useTransition();
+  const [iconSearch, setIconSearch] = React.useState("");
   const form = useForm<CategoryFormValues>({
     resolver: zodResolver(categoryFormSchema),
     defaultValues,
+  });
+  const selectedIcon = form.watch("icon");
+
+  const visibleIconOptions = CATEGORY_ICON_OPTIONS.filter((option) => {
+    const normalizedSearch = iconSearch.trim().toLocaleLowerCase("es");
+
+    if (!normalizedSearch) {
+      return true;
+    }
+
+    return [option.label, option.slug, ...option.keywords]
+      .join(" ")
+      .toLocaleLowerCase("es")
+      .includes(normalizedSearch);
   });
 
   useEffect(() => {
@@ -103,20 +119,58 @@ export function CategoryForm({
           ) : null}
         </label>
 
-        <label className="auth-field" htmlFor={`${fieldIdPrefix}-icon`}>
-          <span className="auth-label">Ícono</span>
-          <input
-            id={`${fieldIdPrefix}-icon`}
-            className="auth-input"
-            type="text"
-            placeholder="receipt-text"
+        <fieldset className="auth-field category-icon-picker">
+          <legend className="auth-label" id={`${fieldIdPrefix}-icon-label`}>
+            Ícono
+          </legend>
+          <input id={`${fieldIdPrefix}-icon`} type="hidden" {...form.register("icon")} />
+          <label className="category-icon-search" htmlFor={`${fieldIdPrefix}-icon-search`}>
+            <span className="sr-only">Buscar ícono</span>
+            <input
+              id={`${fieldIdPrefix}-icon-search`}
+              className="auth-input"
+              type="search"
+              placeholder="Buscar ícono"
+              value={iconSearch}
+              onChange={(event) => setIconSearch(event.target.value)}
+            />
+          </label>
+          <div
+            className="category-icon-grid"
+            role="radiogroup"
+            aria-labelledby={`${fieldIdPrefix}-icon-label`}
             aria-invalid={Boolean(form.formState.errors.icon)}
-            {...form.register("icon")}
-          />
+          >
+            {visibleIconOptions.length > 0 ? (
+              visibleIconOptions.map((option) => {
+                const isSelected = selectedIcon === option.slug;
+
+                return (
+                  <button
+                    key={option.slug}
+                    className={`category-icon-option${isSelected ? " category-icon-option-selected" : ""}`}
+                    type="button"
+                    role="radio"
+                    aria-checked={isSelected}
+                    aria-label={option.label}
+                    title={option.label}
+                    onClick={() => {
+                      form.setValue("icon", option.slug, { shouldDirty: true, shouldValidate: true });
+                    }}
+                  >
+                    <CategoryIcon icon={option.slug} size={20} />
+                    <span>{option.label}</span>
+                  </button>
+                );
+              })
+            ) : (
+              <p className="category-icon-empty">No encontramos íconos para esa búsqueda.</p>
+            )}
+          </div>
           {form.formState.errors.icon ? (
             <span className="auth-field-error">{form.formState.errors.icon.message}</span>
           ) : null}
-        </label>
+        </fieldset>
 
         <label className="auth-field" htmlFor={`${fieldIdPrefix}-color`}>
           <span className="auth-label">Color</span>

--- a/frontend/src/components/categories/category-form.tsx
+++ b/frontend/src/components/categories/category-form.tsx
@@ -17,6 +17,43 @@ export const DEFAULT_CATEGORY_FORM_VALUES: CategoryFormValues = {
   color: "#D97706",
 };
 
+const CATEGORY_COLOR_OPTIONS = [
+  "#D97706",
+  "#EA580C",
+  "#DC2626",
+  "#E11D48",
+  "#DB2777",
+  "#C026D3",
+  "#9333EA",
+  "#7C3AED",
+  "#4F46E5",
+  "#2563EB",
+  "#0284C7",
+  "#0891B2",
+  "#0D9488",
+  "#059669",
+  "#16A34A",
+  "#65A30D",
+  "#84CC16",
+  "#CA8A04",
+  "#A16207",
+  "#92400E",
+  "#78716C",
+  "#52525B",
+  "#374151",
+  "#111827",
+] as const;
+
+function getColorOptions(currentColor: string): string[] {
+  const normalizedColor = currentColor.trim().toUpperCase();
+
+  if (!normalizedColor || CATEGORY_COLOR_OPTIONS.includes(normalizedColor as (typeof CATEGORY_COLOR_OPTIONS)[number])) {
+    return [...CATEGORY_COLOR_OPTIONS];
+  }
+
+  return [normalizedColor, ...CATEGORY_COLOR_OPTIONS];
+}
+
 type CategoryFormProps = {
   defaultValues?: CategoryFormValues;
   submitLabel: string;
@@ -43,6 +80,8 @@ export function CategoryForm({
     defaultValues,
   });
   const selectedIcon = form.watch("icon");
+  const selectedColor = form.watch("color");
+  const colorOptions = getColorOptions(selectedColor || defaultValues.color);
 
   const visibleIconOptions = CATEGORY_ICON_OPTIONS.filter((option) => {
     const normalizedSearch = iconSearch.trim().toLocaleLowerCase("es");
@@ -83,8 +122,8 @@ export function CategoryForm({
   });
 
   return (
-    <form className="workspace-form" onSubmit={onSubmit} noValidate>
-      <div className="entity-split-grid">
+    <form className="workspace-form category-form" onSubmit={onSubmit} noValidate>
+      <div className="category-form-grid">
         <label className="auth-field" htmlFor={`${fieldIdPrefix}-name`}>
           <span className="auth-label">Nombre</span>
           <input
@@ -119,7 +158,7 @@ export function CategoryForm({
           ) : null}
         </label>
 
-        <fieldset className="auth-field category-icon-picker">
+        <fieldset className="auth-field category-picker-field category-icon-picker">
           <legend className="auth-label" id={`${fieldIdPrefix}-icon-label`}>
             Ícono
           </legend>
@@ -172,20 +211,43 @@ export function CategoryForm({
           ) : null}
         </fieldset>
 
-        <label className="auth-field" htmlFor={`${fieldIdPrefix}-color`}>
-          <span className="auth-label">Color</span>
-          <input
-            id={`${fieldIdPrefix}-color`}
-            className="auth-input"
-            type="text"
-            placeholder="#D97706"
+        <fieldset className="auth-field category-picker-field category-color-picker">
+          <legend className="auth-label" id={`${fieldIdPrefix}-color-label`}>
+            Color
+          </legend>
+          <input id={`${fieldIdPrefix}-color`} type="hidden" {...form.register("color")} />
+          <div
+            className="category-color-grid"
+            role="radiogroup"
+            aria-labelledby={`${fieldIdPrefix}-color-label`}
             aria-invalid={Boolean(form.formState.errors.color)}
-            {...form.register("color")}
-          />
+          >
+            {colorOptions.map((color) => {
+              const normalizedColor = color.toUpperCase();
+              const isSelected = selectedColor.toUpperCase() === normalizedColor;
+
+              return (
+                <button
+                  key={normalizedColor}
+                  className={`category-color-option${isSelected ? " category-color-option-selected" : ""}`}
+                  type="button"
+                  role="radio"
+                  aria-checked={isSelected}
+                  aria-label={`Color ${normalizedColor}`}
+                  title={normalizedColor}
+                  onClick={() => {
+                    form.setValue("color", normalizedColor, { shouldDirty: true, shouldValidate: true });
+                  }}
+                >
+                  <span aria-hidden="true" style={{ backgroundColor: normalizedColor }} />
+                </button>
+              );
+            })}
+          </div>
           {form.formState.errors.color ? (
             <span className="auth-field-error">{form.formState.errors.color.message}</span>
           ) : null}
-        </label>
+        </fieldset>
       </div>
 
       <div className="entity-actions">

--- a/frontend/src/lib/categories/icons.tsx
+++ b/frontend/src/lib/categories/icons.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import {
+  Archive,
+  Banknote,
+  BriefcaseBusiness,
+  Bus,
+  Car,
+  ChartNoAxesColumn,
+  CircleHelp,
+  Clapperboard,
+  Dumbbell,
+  Gift,
+  GraduationCap,
+  HandCoins,
+  HeartPulse,
+  Home,
+  Landmark,
+  PawPrint,
+  Plane,
+  ReceiptText,
+  Shirt,
+  ShoppingBasket,
+  ShoppingCart,
+  Tag,
+  UtensilsCrossed,
+  WalletCards,
+  Wrench,
+  type LucideIcon,
+} from "lucide-react";
+
+export type CategoryIconOption = {
+  slug: string;
+  label: string;
+  keywords: string[];
+  Icon: LucideIcon;
+};
+
+export const CATEGORY_ICON_OPTIONS: CategoryIconOption[] = [
+  { slug: "receipt-text", label: "Recibo", keywords: ["factura", "ticket", "comprobante"], Icon: ReceiptText },
+  { slug: "utensils-crossed", label: "Comida", keywords: ["alimentación", "restaurante", "cena"], Icon: UtensilsCrossed },
+  { slug: "shopping-basket", label: "Supermercado", keywords: ["compras", "mercado", "canasta"], Icon: ShoppingBasket },
+  { slug: "shopping-cart", label: "Compras", keywords: ["tienda", "carrito", "gastos"], Icon: ShoppingCart },
+  { slug: "paw-print", label: "Mascotas", keywords: ["perro", "gato", "animales"], Icon: PawPrint },
+  { slug: "archive", label: "Archivo", keywords: ["caja", "histórico"], Icon: Archive },
+  { slug: "home", label: "Hogar", keywords: ["casa", "alquiler", "vivienda"], Icon: Home },
+  { slug: "car", label: "Auto", keywords: ["vehículo", "nafta", "transporte"], Icon: Car },
+  { slug: "bus", label: "Transporte", keywords: ["colectivo", "viaje", "movilidad"], Icon: Bus },
+  { slug: "plane", label: "Viajes", keywords: ["vacaciones", "avión", "turismo"], Icon: Plane },
+  { slug: "heart-pulse", label: "Salud", keywords: ["médico", "farmacia", "bienestar"], Icon: HeartPulse },
+  { slug: "dumbbell", label: "Deporte", keywords: ["gimnasio", "fitness", "actividad"], Icon: Dumbbell },
+  { slug: "clapperboard", label: "Entretenimiento", keywords: ["cine", "series", "salidas"], Icon: Clapperboard },
+  { slug: "shirt", label: "Ropa", keywords: ["indumentaria", "vestimenta", "moda"], Icon: Shirt },
+  { slug: "graduation-cap", label: "Educación", keywords: ["estudio", "cursos", "aprendizaje"], Icon: GraduationCap },
+  { slug: "briefcase-business", label: "Trabajo", keywords: ["negocio", "oficina", "profesional"], Icon: BriefcaseBusiness },
+  { slug: "gift", label: "Regalos", keywords: ["cumpleaños", "presente", "celebración"], Icon: Gift },
+  { slug: "wrench", label: "Mantenimiento", keywords: ["arreglo", "reparación", "servicio"], Icon: Wrench },
+  { slug: "banknote", label: "Efectivo", keywords: ["dinero", "billete", "cash"], Icon: Banknote },
+  { slug: "wallet-cards", label: "Billetera", keywords: ["tarjeta", "cuenta", "pago"], Icon: WalletCards },
+  { slug: "landmark", label: "Banco", keywords: ["finanzas", "institución", "ahorro"], Icon: Landmark },
+  { slug: "hand-coins", label: "Ingresos", keywords: ["sueldo", "cobro", "ganancia"], Icon: HandCoins },
+  { slug: "chart-no-axes-column", label: "Análisis", keywords: ["gráfico", "estadística", "balance"], Icon: ChartNoAxesColumn },
+  { slug: "tag", label: "Etiqueta", keywords: ["categoría", "general", "otros"], Icon: Tag },
+];
+
+const CATEGORY_ICON_ALIASES: Record<string, string> = {
+  briefcase: "briefcase-business",
+  chart: "chart-no-axes-column",
+  chartColumn: "chart-no-axes-column",
+  shopping: "shopping-cart",
+  utensils: "utensils-crossed",
+};
+
+export function normalizeCategoryIconSlug(icon: string): string {
+  const trimmedIcon = icon.trim();
+
+  return CATEGORY_ICON_ALIASES[trimmedIcon] ?? trimmedIcon;
+}
+
+export function getCategoryIconOption(icon: string): CategoryIconOption | null {
+  const normalizedIcon = normalizeCategoryIconSlug(icon);
+
+  return CATEGORY_ICON_OPTIONS.find((option) => option.slug === normalizedIcon) ?? null;
+}
+
+type CategoryIconProps = {
+  icon: string;
+  size?: number;
+};
+
+export function CategoryIcon({ icon, size = 18 }: CategoryIconProps) {
+  const iconOption = getCategoryIconOption(icon);
+  const Icon = iconOption?.Icon ?? CircleHelp;
+
+  return <Icon aria-hidden="true" focusable="false" size={size} />;
+}


### PR DESCRIPTION
Closes #64

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Render category Lucide icons from stored icon slugs instead of showing raw text.
- Replace manual icon entry with an accessible searchable icon picker.
- Replace manual color entry with a crisp predefined color palette and responsive picker layout.

## Changes
| File | Change |
|------|--------|
| `frontend/src/lib/categories/icons.tsx` | Adds category icon registry, slug normalization, and Lucide renderer. |
| `frontend/src/components/categories/category-form.tsx` | Adds searchable icon picker and predefined color palette. |
| `frontend/src/components/categories/categories-panel.tsx` | Renders actual category icons in cards. |
| `frontend/src/components/categories/categories-panel.test.tsx` | Updates create/edit tests for icon and color picker interactions. |
| `frontend/app/globals.css` | Adds responsive picker layout and crisp color swatch styles. |

## Test Plan
- [x] `pnpm exec vitest run src/components/categories/categories-panel.test.tsx`
- [x] `pnpm run typecheck`
- [x] `docker compose build --no-cache frontend && docker compose up -d frontend proxy`
- [x] Manually tested category edit UI in Playwright at 329x876 portrait and 876x329 landscape.
- [x] Verified color swatches render without blurred inset shadows.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran relevant validation for modified frontend code
- [x] Docs updated if behavior changed, or not required
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers